### PR TITLE
Updated secret name to fix K8s deployment issue

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
@@ -30,7 +30,7 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    hmpps-template-kotlin:
+    hmpps-electronic-monitoring-datastore-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       # TODO: Check that the appinsights_instrumentaitonKey exists in the NS
       # Example client registration secrets


### PR DESCRIPTION
As per Kubectl logs:
1. `kubectl config set-context --current --namespace=tst-em-example-app-jkn-dev`
2. `kubectl get pods`
3. `kubectl describe pod hmpps-electronic-monitoring-datastore-api-c5fff4759-lljqc`
