### PR TITLE
Fixing incorrect context value for CircleCI preprod & prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
           pipeline_number: <<pipeline.number>>
           context:
             - hmpps-common-vars
-            - hmpps-electronic-monitoring-datastore-api-preprod
+            - hmpps-electronic-monitoring-datastore-preprod
           requires:
             - request-preprod-approval
           helm_timeout: 5m
@@ -103,7 +103,7 @@ workflows:
 #          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
 #          context:
 #            - hmpps-common-vars
-#            - hmpps-electronic-monitoring-datastore-api-prod
+#            - hmpps-electronic-monitoring-datastore-prod
 #          requires:
 #            - request-prod-approval
 #          helm_timeout: 5m


### PR DESCRIPTION
This needs to match the context set in the hmpps-project-bootstrap projects.json file, which creates this context in the MoJ CircleCi organisation.

Incorrect values seem to be ignored, resulting in preprod deployments overwriting values set in dev and e.g. breaking ingress ENV variable -> can't route to the app URL