### PR TITLE
added override for trivy repo to fix rate limit issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
-
+  
 workflows:
   version: 2
   build-test-and-deploy:
@@ -125,6 +125,7 @@ workflows:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          additional_args: --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:


### PR DESCRIPTION
Trivy is failing for rate limiting reasons.

This is being seen in other repos, and has been fixed with GH actions as follows:
https://github.com/ministryofjustice/analytical-platform-kubectl/pull/103/files

The documentation for the trivy CLI flags is here:
https://aquasecurity.github.io/trivy/v0.40/docs/vulnerability/db/

This fix combines the above, passing in an additional parameter as per the circleCI orb trivy action source here:
https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/jobs/trivy_latest_scan.yml 