### PR TITLE
AM Order details implementation spike

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/AmOrderDetailsQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/AmOrderDetailsQueryBuilder.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers.querybuilders
+
+import org.apache.commons.lang3.StringUtils.isAlphanumeric
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsQuery
+
+class AmOrderDetailsQueryBuilder(
+  private val databaseName: String? = "test_database",
+) {
+  var legacySubjectId: String? = null
+
+  fun withLegacySubjectId(subjectId: String): AmOrderDetailsQueryBuilder {
+    if (!isAlphanumeric(subjectId)) {
+      throw IllegalArgumentException("Input contains illegal characters")
+    }
+
+    // TODO: Consider using PreparedStatement and a library to avoid manual SQL assembly
+    // val testQuery: String = "SELECT * FROM ?.my_table WHERE user_id = ?"
+    // val connection: Connection = null
+    // val statement: PreparedStatement = connection.prepareStatement(testQuery)
+
+    legacySubjectId = subjectId
+    return this
+  }
+
+  fun build(): AthenaAmOrderDetailsQuery = AthenaAmOrderDetailsQuery(
+    """
+      SELECT
+        id
+      , legacy_order_id
+      , legacy_subject_id
+      , first_name
+      , last_name
+      , alias
+      , date_of_birth date
+      , legacy_gender
+      , primary_address_line1
+      , primary_address_line2
+      , primary_address_line3
+      , primary_address_postcode
+      , phone_number1
+      , order_start_date date
+      , order_end_date date
+      , order_type
+      , order_type_description
+      , enforceable_condition
+      , order_end_outcome
+      , responsible_org_details_phone_number
+      , responsible_org_details_email
+      , tag_at_source
+      , special_instructions
+      FROM 
+        $databaseName.am_order_details
+      WHERE
+        legacy_subject_id=$legacySubjectId
+    """.trimIndent(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/AmOrderDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/AmOrderDetails.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsDTO
+
+data class AmOrderDetails(
+  val specials: String,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
+  val firstName: String? = "",
+  val lastName: String? = "",
+  val alias: String? = "",
+  val dateOfBirth: String? = "",
+
+  val sex: String? = "",
+
+  val primaryAddressLine1: String? = "",
+  val primaryAddressLine2: String? = "",
+  val primaryAddressLine3: String? = "",
+  val primaryAddressPostCode: String? = "",
+  val phoneOrMobileNumber: String? = "",
+
+  // Many fields not present in AM order, only in normal orders
+
+  val orderStartDate: String? = "",
+  val orderEndDate: String? = "",
+  val orderType: String? = "",
+  val orderTypeDescription: String? = "",
+
+  val enforceableCondition: String? = "",
+  val orderEndOutcome: String? = "",
+  val responsibleOrgDetailsPhoneNumber: String? = "",
+  val responsibleOrgDetailsEmail: String? = "",
+  val tagAtSource: String? = "",
+  val specialInstructions: String? = "",
+) {
+  constructor(dto: AthenaAmOrderDetailsDTO) : this (
+    specials = "no",
+    legacySubjectId = dto.legacySubjectId,
+    legacyOrderId = dto.legacyOrderId,
+    firstName = dto.firstName,
+    lastName = dto.lastName,
+    alias = dto.alias,
+    dateOfBirth = dto.dateOfBirth,
+    sex = dto.sex,
+    primaryAddressLine1 = dto.primaryAddressLine1,
+    primaryAddressLine2 = dto.primaryAddressLine2,
+    primaryAddressLine3 = dto.primaryAddressLine3,
+    primaryAddressPostCode = dto.primaryAddressPostCode,
+    phoneOrMobileNumber = dto.phoneOrMobileNumber,
+    orderStartDate = dto.orderStartDate,
+    orderEndDate = dto.orderEndDate,
+    orderType = dto.orderType,
+    orderTypeDescription = dto.orderTypeDescription,
+    enforceableCondition = dto.enforceableCondition,
+    orderEndOutcome = dto.orderEndOutcome,
+    responsibleOrgDetailsPhoneNumber = dto.responsibleOrgDetailsPhoneNumber,
+    responsibleOrgDetailsEmail = dto.responsibleOrgDetailsEmail,
+    tagAtSource = dto.tagAtSource,
+    specialInstructions = dto.specialInstructions,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaAmOrderDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaAmOrderDetailsDTO.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+// TODO: Check which fields are nullable
+data class AthenaAmOrderDetailsDTO(
+  val legacySubjectId: String,
+  val legacyOrderId: String,
+  val firstName: String? = "",
+  val lastName: String? = "",
+  val alias: String? = "",
+  val dateOfBirth: String? = "",
+
+  @JsonProperty("legacy_gender")
+  val sex: String? = "",
+
+  @JsonProperty("primary_address_line1")
+  val primaryAddressLine1: String? = "",
+  @JsonProperty("primary_address_line2")
+  val primaryAddressLine2: String? = "",
+  @JsonProperty("primary_address_line3")
+  val primaryAddressLine3: String? = "",
+  val primaryAddressPostCode: String? = "",
+  @JsonProperty("phone_number1")
+  val phoneOrMobileNumber: String? = "",
+
+  // Many fields not present in AM order, only in normal orders
+
+  val orderStartDate: String? = "",
+  val orderEndDate: String? = "",
+  val orderType: String? = "",
+  val orderTypeDescription: String? = "",
+
+  val enforceableCondition: String? = "",
+  val orderEndOutcome: String? = "",
+  val responsibleOrgDetailsPhoneNumber: String? = "",
+  val responsibleOrgDetailsEmail: String? = "",
+  val tagAtSource: String? = "",
+  val specialInstructions: String? = "",
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaQuery.kt
@@ -51,3 +51,8 @@ data class AthenaSuspensionOfVisitsListQuery(
 data class AthenaEquipmentDetailsListQuery(
   override val queryString: String,
 ) : AthenaQuery(queryString)
+
+// AM Query types
+data class AthenaAmOrderDetailsQuery(
+  override val queryString: String,
+) : AthenaQuery(queryString)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepository.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.repository
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.EmDatastoreClientInterface
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers.AthenaHelper
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers.querybuilders.AmOrderDetailsQueryBuilder
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsDTO
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsQuery
+
+@Service
+class AmOrderDetailsRepository(
+  @Autowired val athenaClient: EmDatastoreClientInterface,
+) {
+  fun getAmOrderDetails(orderId: String, role: AthenaRole): AthenaAmOrderDetailsDTO {
+    val amOrderDetailsQuery: AthenaAmOrderDetailsQuery = AmOrderDetailsQueryBuilder()
+      .withLegacySubjectId(orderId)
+      .build()
+
+    val athenaResponse = athenaClient.getQueryResult(amOrderDetailsQuery, role)
+
+    val result = AthenaHelper.mapTo<AthenaAmOrderDetailsDTO>(athenaResponse)
+
+    return result.first()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resource/OrderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resource/OrderController.kt
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.AmOrderDetails
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.OrderDetails
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.OrderInformation
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AmOrderService
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AthenaRoleService
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.OrderService
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.internal.AuditService
@@ -20,6 +22,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.int
 @RequestMapping(value = ["/orders"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class OrderController(
   @Autowired val orderService: OrderService,
+  val amOrderService: AmOrderService,
   val athenaRoleService: AthenaRoleService,
 
   // TODO: Re-enable audit as @autowired once Cloud Platform in place
@@ -100,6 +103,24 @@ class OrderController(
     auditService?.createEvent(
       authentication.name,
       "GET_ORDER_DETAILS",
+      mapOf("orderId" to orderId),
+    )
+
+    return ResponseEntity.ok(result)
+  }
+
+  @GetMapping("/AM/getOrderDetails/{orderId}")
+  fun getAmOrderDetails(
+    authentication: Authentication,
+    @PathVariable(required = true) orderId: String,
+  ): ResponseEntity<AmOrderDetails> {
+    val validatedRole = athenaRoleService.getRoleFromAuthentication(authentication)
+
+    val result = amOrderService.getAmOrderDetails(orderId, validatedRole)
+
+    auditService?.createEvent(
+      authentication.name,
+      "GET_AM_ORDER_DETAILS",
       mapOf("orderId" to orderId),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AmOrderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AmOrderService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.AmOrderDetails
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsDTO
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.repository.AmOrderDetailsRepository
+import kotlin.String
+
+@Service
+class AmOrderService(
+  @Autowired val amOrderDetailsRepository: AmOrderDetailsRepository,
+) {
+  fun getAmOrderDetails(orderId: String, role: AthenaRole): AmOrderDetails {
+    val amOrderDetailsDTO: AthenaAmOrderDetailsDTO = amOrderDetailsRepository.getAmOrderDetails(orderId, role)
+    return AmOrderDetails(amOrderDetailsDTO)
+  }
+}

--- a/src/main/resources/dataTemplateNotes/orderDetails/am
+++ b/src/main/resources/dataTemplateNotes/orderDetails/am
@@ -1,0 +1,42 @@
+  id bigint,
+  legacy_order_id string,
+  legacy_subject_id string,
+  first_name string,
+  last_name string,
+
+  alias string,
+  date_of_birth date,
+
+  legacy_gender string,
+
+  primary_address_line1 string,
+  primary_address_line2 string,
+  primary_address_line3 string,
+  primary_address_postcode string,
+  phone_number1 string,
+
+
+
+
+
+
+
+
+
+
+
+  order_start_date date,
+  order_end_date date,
+  order_type string,
+  order_type_description string,
+
+
+        enforceable_condition string,
+        order_end_outcome string,
+        responsible_org_details_phone_number string,
+        responsible_org_details_email string,
+
+
+
+        tag_at_source string,
+        special_instructions string

--- a/src/main/resources/dataTemplateNotes/orderDetails/non-am
+++ b/src/main/resources/dataTemplateNotes/orderDetails/non-am
@@ -1,0 +1,40 @@
+  order_sid bigint,                <<NAME CHANGE
+  legacy_subject_id bigint,        <<DATATYPE CHANGE
+  legacy_order_id bigint,          <<DATATYPE CHANGE
+  first_name string,
+  last_name string,
+        full_name string,
+  alias string,
+  date_of_birth date,
+  adult_or_child string,
+  sex string,                       <<POTENTIAL NAME CHANGE
+        contact string,
+  primary_address_line_1 string,    <<FORMATTING CHANGE
+  primary_address_line_2 string,    <<FORMATTING CHANGE
+  primary_address_line_3 string,    <<FORMATTING CHANGE
+  primary_address_post_code string, <<FORMATTING CHANGE
+  phone_or_mobile_number string,    <<NAME CHANGE
+        ppo string,
+        mappa string,
+        technical_bail string,
+        wearing_wrist_pid string,
+        manual_risk string,
+        offence_risk boolean,
+        post_code_risk string,
+        false_limb_risk string,
+        migrated_risk string,
+        range_risk string,
+        report_risk string,
+  order_start_date date,
+  order_end_date date,
+  order_type string,
+  order_type_description string,
+        order_type_detail string,
+        notifying_organisation_details_name string,
+
+
+
+
+        responsible_organisation string,
+        responsible_organisation_details_region string,
+        specials_flag int

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/AmOrderDetailsQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/AmOrderDetailsQueryBuilderTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers.querybuilders
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AmOrderDetailsQueryBuilderTest {
+
+  fun replaceWhitespace(text: String): String = text.replace("\\s+".toRegex(), " ")
+
+  val baseQuery: String = """
+      SELECT
+        id
+      , legacy_order_id
+      , legacy_subject_id
+      , first_name
+      , last_name
+      , alias
+      , date_of_birth date
+      , legacy_gender
+      , primary_address_line1
+      , primary_address_line2
+      , primary_address_line3
+      , primary_address_postcode
+      , phone_number1
+      , order_start_date date
+      , order_end_date date
+      , order_type
+      , order_type_description
+      , enforceable_condition
+      , order_end_outcome
+      , responsible_org_details_phone_number
+      , responsible_org_details_email
+      , tag_at_source
+      , special_instructions
+      FROM 
+        test_database.am_order_details
+      WHERE 
+  """.trimIndent()
+
+  @Test
+  fun `returns valid SQL if legacySubjectId is populated`() {
+    val legacySubjectId = "111222333"
+
+    val expectedSQL = replaceWhitespace(
+      baseQuery + """
+            legacy_subject_id=$legacySubjectId
+      """.trimIndent(),
+    )
+
+    val result = AmOrderDetailsQueryBuilder()
+      .withLegacySubjectId(legacySubjectId)
+      .build()
+
+    Assertions.assertThat(replaceWhitespace(result.queryString)).isEqualTo(expectedSQL)
+  }
+
+  @Test
+  fun `throws an error if input contains dangerous characters`() {
+    val dangerousInput: String = "12345 OR 1=1"
+
+    Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
+      AmOrderDetailsQueryBuilder()
+        .withLegacySubjectId(dangerousInput)
+        .build()
+    }.withMessage("Input contains illegal characters")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepositoryTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.EmDatastoreClient
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers.AthenaHelper
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsDTO
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaQuery
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.metaDataRow
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.varCharValueColumn
+
+class AmOrderDetailsRepositoryTest {
+  private lateinit var emDatastoreClient: EmDatastoreClient
+  private lateinit var repository: AmOrderDetailsRepository
+
+  fun amOrderDetailsData(subjectId: String, orderId: String, responsibleOrgDetailsPhoneNumber: String) = """
+    {
+      "Data": [
+        ${varCharValueColumn(subjectId)},
+        ${varCharValueColumn(orderId)},
+        ${varCharValueColumn(responsibleOrgDetailsPhoneNumber)},
+      ]
+    }
+  """.trimIndent()
+
+  fun amOrderDetailsResultSet(
+    subjectId: String? = "1234",
+    orderId: String? = "fakeOrderId",
+    phoneNumber: String? = "fakePhoneNumber",
+  ) = """
+    {
+      "ResultSet": {
+        "Rows": [
+          {
+            "Data": [
+              ${varCharValueColumn("legacy_subject_id")},
+            ]
+          },
+          ${amOrderDetailsData(subjectId!!, orderId!!, phoneNumber!!)},
+          ${amOrderDetailsData("5678", "This row should never be returned", "01134567890")}
+        ],
+        "ResultSetMetadata": {
+          "ColumnInfo": [
+            ${metaDataRow("legacy_subject_id")},
+            ${metaDataRow("legacy_order_id")},
+            ${metaDataRow("responsible_org_details_phone_number", "boolean")}
+          ]
+        }
+      },
+      "UpdateCount": 0
+    }
+  """.trimIndent()
+
+  @BeforeEach
+  fun setup() {
+    emDatastoreClient = Mockito.mock(EmDatastoreClient::class.java)
+    repository = AmOrderDetailsRepository(emDatastoreClient)
+  }
+
+  @Test
+  fun `AmOrderDetailsRepository can be instantiated`() {
+    val sut = OrderRepository(Mockito.mock(EmDatastoreClient::class.java))
+    Assertions.assertThat(sut).isNotNull()
+  }
+
+  @Nested
+  inner class GetOrderDetails {
+    @Test
+    fun `getAmOrderDetails calls getQueryResult`() {
+      val resultSet = AthenaHelper.resultSetFromJson(amOrderDetailsResultSet())
+
+      Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
+
+      repository.getAmOrderDetails("123", AthenaRole.DEV)
+
+      Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
+    }
+
+    @Test
+    fun `getAmOrderDetails returns an AthenaAmOrderDetailsDTO`() {
+      val resultSet = AthenaHelper.resultSetFromJson(amOrderDetailsResultSet())
+
+      Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
+
+      val result = repository.getAmOrderDetails("123", AthenaRole.DEV)
+
+      Assertions.assertThat(result).isInstanceOf(AthenaAmOrderDetailsDTO::class.java)
+    }
+
+    @Test
+    fun `getAmOrderDetails returns the first result from getQueryResult`() {
+      val orderId = "expectedId"
+      val resultSet = AthenaHelper.resultSetFromJson(amOrderDetailsResultSet(orderId))
+
+      Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
+
+      val result = repository.getAmOrderDetails(orderId, AthenaRole.DEV)
+
+      Assertions.assertThat(result).isNotNull
+      Assertions.assertThat(result.legacySubjectId).isEqualTo(orderId)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AmOrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AmOrderServiceTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.services
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.`when`
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.AmOrderDetails
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaAmOrderDetailsDTO
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.repository.AmOrderDetailsRepository
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AmOrderService
+
+class AmOrderServiceTest {
+  private lateinit var amOrderDetailsRepository: AmOrderDetailsRepository
+  private lateinit var service: AmOrderService
+
+  @BeforeEach
+  fun setup() {
+    amOrderDetailsRepository = mock(AmOrderDetailsRepository::class.java)
+    service = AmOrderService(amOrderDetailsRepository)
+  }
+
+  @Test
+  fun `AmOrderService can be instantiated`() {
+    Assertions.assertThat(service).isNotNull()
+  }
+
+  @Nested
+  inner class GetOrderDetails {
+    val orderId = "fake-id"
+
+    val blankOrderDetails = AthenaAmOrderDetailsDTO(
+      legacySubjectId = "",
+      legacyOrderId = "",
+      responsibleOrgDetailsPhoneNumber = "",
+    )
+
+    @BeforeEach
+    fun setup() {
+      `when`(amOrderDetailsRepository.getAmOrderDetails(orderId, AthenaRole.DEV))
+        .thenReturn(blankOrderDetails)
+    }
+
+    @Test
+    fun `calls getAmOrderDetails from order details repository`() {
+      service.getAmOrderDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(amOrderDetailsRepository, times(1)).getAmOrderDetails(orderId, AthenaRole.DEV)
+    }
+
+    @Test
+    fun `returns AmOrderDetails`() {
+      val result = service.getAmOrderDetails(orderId, AthenaRole.DEV)
+
+      Assertions.assertThat(result).isInstanceOf(AmOrderDetails::class.java)
+    }
+
+    @Test
+    fun `returns correct details of the order`() {
+      val result = service.getAmOrderDetails(orderId, AthenaRole.DEV)
+
+      Assertions.assertThat(result).isNotNull
+      Assertions.assertThat(result.legacySubjectId).isEqualTo("")
+      Assertions.assertThat(result.specials).isEqualTo("no")
+    }
+  }
+}


### PR DESCRIPTION
- Added framework for AM order details endpoint
- AmOrderDetails in place down to repository layer
- End-to-end implementation of AM order details API endpoint.
- No mock data yet in place for this query in Athena