### PR TITLE
Modify the address property of OrderSearchResult data class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
@@ -6,7 +6,10 @@ data class OrderSearchResult(
   val dataType: String,
   val legacySubjectId: Long,
   val name: String,
-  val address: String,
+  val addressLine1: String,
+  val addressLine2: String,
+  val addressLine3: String,
+  val addressPostcode: String,
   val alias: String?,
   val dateOfBirth: String,
   val orderStartDate: String,
@@ -16,12 +19,10 @@ data class OrderSearchResult(
     dataType = "am",
     legacySubjectId = dto.legacySubjectId,
     name = dto.fullName,
-    address = StringBuilder()
-      .append(dto.primaryAddressLine1)
-      .append(dto.primaryAddressLine2)
-      .append(dto.primaryAddressLine3)
-      .append(dto.primaryAddressPostCode)
-      .toString(),
+    addressLine1 = dto.primaryAddressLine1,
+    addressLine2 = dto.primaryAddressLine2,
+    addressLine3 = dto.primaryAddressLine3,
+    addressPostcode = dto.primaryAddressPostCode,
     alias = null,
     dateOfBirth = dto.orderStartDate,
     orderStartDate = dto.orderStartDate,


### PR DESCRIPTION
Modify the OrderSearchResult data class so that the API returns the order address as four separate string values (address line 1, line 2 etc), rather than a single string.
This allows the address to be rendered correctly in the UI.