### PR TITLE
Improving athena role assignment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,10 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     ATHENA_DATABASE_NAME: "historic_api_mart"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
+
+    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
+    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
+    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
   #                                  <== COMMENTED OUT to investigate failing build 20/12/2024

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,10 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     ATHENA_DATABASE_NAME: "historic_api_mart"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
+
+    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
+    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
+    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
   #                                  <== COMMENTED OUT to investigate failing build 20/12/2024

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,10 @@ generic-service:
     ATHENA_DATABASE_NAME: "historic_api_mart"
 #    ATHENA_OUTPUT_BUCKET: "s3://emds-prod-athena-query-results-20240918073115959600000002"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
+
+    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
+    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
+    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
 #  namespace_secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
@@ -1,23 +1,15 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client
 
 enum class AthenaRole(
-  val iamRole: String,
   val priority: Int,
 ) {
-/*  TODO: Currently the 'restricted' role is the same as the non-restricted role.
-*    We will need to replace this with the IAM role that is allowed to access Specials data
-*    This is dependent on the security being in place and approved for that change
-* */
   ROLE_EM_DATASTORE_RESTRICTED_RO(
-    "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
     priority = 20,
   ),
   ROLE_EM_DATASTORE_GENERAL_RO(
-    "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
     priority = 10,
   ),
   NONE(
-    "",
     priority = 0,
   ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
@@ -4,8 +4,6 @@ enum class AthenaRole(
   val iamRole: String,
   val priority: Int,
 ) {
-  DEV("arn:aws:iam::396913731313:role/cmt_read_emds_data_test", 5),
-
 /*  TODO: Currently the 'restricted' role is the same as the non-restricted role.
 *    We will need to replace this with the IAM role that is allowed to access Specials data
 *    This is dependent on the security being in place and approved for that change

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/AthenaRole.kt
@@ -1,10 +1,25 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client
 
-enum class AthenaRole(val iamRole: String) {
-//  DEV("arn:aws:iam::800964199911:role/cmt_read_emds_data_dev"),
-  DEV("arn:aws:iam::396913731313:role/cmt_read_emds_data_test"),
-  TEST("arn:aws:iam::396913731313:role/cmt_read_emds_data_test"),
-  NONE(""),
-  ROLE_EM_DATASTORE_RESTRICTED_RO("TBC"),
-  ROLE_EM_DATASTORE_GENERAL_RO("arn:aws:iam::800964199911:role/cmt_read_emds_data_dev"),
+enum class AthenaRole(
+  val iamRole: String,
+  val priority: Int,
+) {
+  DEV("arn:aws:iam::396913731313:role/cmt_read_emds_data_test", 5),
+
+/*  TODO: Currently the 'restricted' role is the same as the non-restricted role.
+*    We will need to replace this with the IAM role that is allowed to access Specials data
+*    This is dependent on the security being in place and approved for that change
+* */
+  ROLE_EM_DATASTORE_RESTRICTED_RO(
+    "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
+    priority = 20,
+  ),
+  ROLE_EM_DATASTORE_GENERAL_RO(
+    "arn:aws:iam::396913731313:role/cmt_read_emds_data_test",
+    priority = 10,
+  ),
+  NONE(
+    "",
+    priority = 0,
+  ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
@@ -18,11 +18,14 @@ import software.amazon.awssdk.services.athena.model.ResultSet
 import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.config.AthenaClientException
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaQuery
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AthenaRoleService
 
 // We will instantiate as new for now
 @Component
 @Profile("!integration & !mocking")
-class EmDatastoreClient : EmDatastoreClientInterface {
+class EmDatastoreClient(
+  private val athenaRoleService: AthenaRoleService,
+) : EmDatastoreClientInterface {
   @Value("\${services.athena.output}")
   private val output: String = "s3://emds-dev-athena-query-results-20240917144028307600000004"
   private val sleepLength: Long = 1000
@@ -31,8 +34,8 @@ class EmDatastoreClient : EmDatastoreClientInterface {
   private val databaseName: String = "test_database"
   private val defaultRole: AthenaRole = AthenaRole.NONE
 
-  private fun startClient(role: AthenaRole): AthenaClient {
-    val credentialsProvider: AwsCredentialsProvider = EmDatastoreCredentialsProvider.Companion.getRole(role)
+  private fun startClient(iamRole: String): AthenaClient {
+    val credentialsProvider: AwsCredentialsProvider = EmDatastoreCredentialsProvider.Companion.getCredentials(iamRole)
 
     return AthenaClient.builder()
       .region(Region.EU_WEST_2)
@@ -41,14 +44,18 @@ class EmDatastoreClient : EmDatastoreClientInterface {
   }
 
   override fun getQueryExecutionId(athenaQuery: AthenaQuery, role: AthenaRole?): String {
-    val athenaClient = startClient(role ?: defaultRole)
+    val iamRole: String = athenaRoleService.getIamRole(role ?: defaultRole)
+
+    val athenaClient = startClient(iamRole)
     val queryExecutionId: String = submitAthenaQuery(athenaClient, athenaQuery.queryString)
     athenaClient.close()
     return queryExecutionId
   }
 
   override fun getQueryResult(queryExecutionId: String, role: AthenaRole?): ResultSet {
-    val athenaClient = startClient(role ?: defaultRole)
+    val iamRole: String = athenaRoleService.getIamRole(role ?: defaultRole)
+
+    val athenaClient = startClient(iamRole)
 
     waitForQueryToComplete(athenaClient, queryExecutionId)
     val resultSet: ResultSet = retrieveResults(athenaClient, queryExecutionId)
@@ -58,7 +65,9 @@ class EmDatastoreClient : EmDatastoreClientInterface {
   }
 
   override fun getQueryResult(athenaQuery: AthenaQuery, role: AthenaRole?): ResultSet {
-    val athenaClient = startClient(role ?: defaultRole)
+    val iamRole: String = athenaRoleService.getIamRole(role ?: defaultRole)
+
+    val athenaClient = startClient(iamRole)
 
     val queryExecutionId: String = submitAthenaQuery(athenaClient, athenaQuery.queryString)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
@@ -29,7 +29,7 @@ class EmDatastoreClient : EmDatastoreClientInterface {
 
   @Value("\${services.athena.database}")
   private val databaseName: String = "test_database"
-  private val defaultRole: AthenaRole = AthenaRole.DEV
+  private val defaultRole: AthenaRole = AthenaRole.NONE
 
   private fun startClient(role: AthenaRole): AthenaClient {
     val credentialsProvider: AwsCredentialsProvider = EmDatastoreRoleProvider.Companion.getRole(role)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreClient.kt
@@ -32,7 +32,7 @@ class EmDatastoreClient : EmDatastoreClientInterface {
   private val defaultRole: AthenaRole = AthenaRole.NONE
 
   private fun startClient(role: AthenaRole): AthenaClient {
-    val credentialsProvider: AwsCredentialsProvider = EmDatastoreRoleProvider.Companion.getRole(role)
+    val credentialsProvider: AwsCredentialsProvider = EmDatastoreCredentialsProvider.Companion.getRole(role)
 
     return AthenaClient.builder()
       .region(Region.EU_WEST_2)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreCredentialsProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreCredentialsProvider.kt
@@ -7,7 +7,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 
-class EmDatastoreRoleProvider {
+class EmDatastoreCredentialsProvider {
   companion object {
     const val SESSION_ID: String = "DataStoreApiSession"
     val region: Region = Region.EU_WEST_2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreCredentialsProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/client/EmDatastoreCredentialsProvider.kt
@@ -12,17 +12,17 @@ class EmDatastoreCredentialsProvider {
     const val SESSION_ID: String = "DataStoreApiSession"
     val region: Region = Region.EU_WEST_2
 
-    fun getRole(role: AthenaRole): AwsCredentialsProvider {
+    fun getCredentials(iamRole: String): AwsCredentialsProvider {
       val useLocalCredentials: Boolean = System.getenv("FLAG_USE_LOCAL_CREDS").toBoolean()
 
       return if (useLocalCredentials) {
         EnvironmentVariableCredentialsProvider.create()
       } else {
-        getModernisationPlatformCredentialsProvider(role)
+        getModernisationPlatformCredentialsProvider(iamRole)
       }
     }
 
-    fun getModernisationPlatformCredentialsProvider(role: AthenaRole): StsAssumeRoleCredentialsProvider {
+    fun getModernisationPlatformCredentialsProvider(iamRole: String): StsAssumeRoleCredentialsProvider {
       val stsClient = StsClient.builder()
         .credentialsProvider(DefaultCredentialsProvider.builder().build())
         .region(region)
@@ -31,7 +31,7 @@ class EmDatastoreCredentialsProvider {
       val credentialsProvider = StsAssumeRoleCredentialsProvider.builder()
         .stsClient(stsClient)
         .refreshRequest { builder ->
-          builder.roleArn(role.iamRole).roleSessionName(SESSION_ID)
+          builder.roleArn(iamRole).roleSessionName(SESSION_ID)
         }
         .build()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
@@ -6,9 +6,9 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.Athe
 
 @Service
 class AthenaRoleService {
-  fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.DEV
+  fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.NONE
 
-  fun getRoleFromAuthenticationOld(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.DEV
+  fun getRoleFromAuthenticationOld(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.NONE
 
   fun getRoleFromAuthentication(authentication: Authentication): AthenaRole {
     val roleStrings: List<String> = (
@@ -17,13 +17,16 @@ class AthenaRoleService {
         as MutableList<String>
       )
 
-    val mappedRoles: List<AthenaRole> = roleStrings.map { roleString ->
-      enumValues<AthenaRole>()
-        .find { it.name == roleString } ?: AthenaRole.NONE
-    }
+    val mappedRoles: List<AthenaRole> = mapToOrderedUniqueRoles(roleStrings)
 
     return mappedRoles.firstOrNull() ?: AthenaRole.NONE
   }
+
+  fun mapToOrderedUniqueRoles(roleStrings: List<String>): List<AthenaRole> = roleStrings
+    .map { roleString ->
+      enumValues<AthenaRole>()
+        .find { it.name == roleString } ?: AthenaRole.NONE
+    }.toSet().sortedByDescending { it.priority }
 }
 
 // Example user token:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
@@ -8,7 +8,11 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.Athe
 class AthenaRoleService {
   fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.DEV
 
-  fun getRoleFromAuthentication(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.DEV
+//  fun getRoleFromAuthentication(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.DEV
+  fun getRoleFromAuthentication(authentication: Authentication): AthenaRole {
+    val x = 3
+    return AthenaRole.NONE
+  }
 }
 
 // Example user token:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
 
 @Service
-class AthenaRoleService {
+class AthenaRoleService(
+  @Value("\${services.athena-roles.restricted:uninitialised}") restrictedRole: String,
+  @Value("\${services.athena-roles.general:uninitialised}") generalRole: String,
+) {
   fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.NONE
 
   fun getRoleFromAuthenticationOld(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.NONE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
@@ -8,10 +8,21 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.Athe
 class AthenaRoleService {
   fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.DEV
 
-//  fun getRoleFromAuthentication(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.DEV
+  fun getRoleFromAuthenticationOld(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.DEV
+
   fun getRoleFromAuthentication(authentication: Authentication): AthenaRole {
-    val x = 3
-    return AthenaRole.NONE
+    val roleStrings: List<String> = (
+      authentication.authorities
+        .map { authority -> authority.authority }
+        as MutableList<String>
+      )
+
+    val mappedRoles: List<AthenaRole> = roleStrings.map { roleString ->
+      enumValues<AthenaRole>()
+        .find { it.name == roleString } ?: AthenaRole.NONE
+    }
+
+    return mappedRoles.firstOrNull() ?: AthenaRole.NONE
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/service/AthenaRoleService.kt
@@ -7,12 +7,14 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.Athe
 
 @Service
 class AthenaRoleService(
-  @Value("\${services.athena-roles.restricted:uninitialised}") restrictedRole: String,
-  @Value("\${services.athena-roles.general:uninitialised}") generalRole: String,
+  /*  TODO: Currently the 'restricted' role is the same as the non-restricted role.
+   *    We will need to replace this with the IAM role that is allowed to access Specials data
+   *    This is dependent on the security being in place and approved for that change
+   * */
+  @Value("\${services.athena-roles.restricted:uninitialised}") private val restrictedRole: String,
+  @Value("\${services.athena-roles.general:uninitialised}") private val generalRole: String,
 ) {
   fun fromString(name: String): AthenaRole = enumValues<AthenaRole>().find { it.name == name } ?: AthenaRole.NONE
-
-  fun getRoleFromAuthenticationOld(authentication: Authentication): AthenaRole = enumValues<AthenaRole>().find { it.name == "TODO!" } ?: AthenaRole.NONE
 
   fun getRoleFromAuthentication(authentication: Authentication): AthenaRole {
     val roleStrings: List<String> = (
@@ -31,6 +33,12 @@ class AthenaRoleService(
       enumValues<AthenaRole>()
         .find { it.name == roleString } ?: AthenaRole.NONE
     }.toSet().sortedByDescending { it.priority }
+
+  fun getIamRole(athenaRole: AthenaRole): String = when (athenaRole.name) {
+    "ROLE_EM_DATASTORE_RESTRICTED_RO" -> restrictedRole
+    "ROLE_EM_DATASTORE_GENERAL_RO" -> generalRole
+    else -> ""
+  }
 }
 
 // Example user token:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,9 @@ services:
     # Values for connecting to DEV Athena instance
 #    database: test_database
 #    output: s3://emds-dev-athena-query-results-20240917144028307600000004
+  athena-roles:
+    restricted: fakeIAM
+    general: fakeIAM2
 
 #CLIENT_ID: hmpps-electronic-monitoring-datastore-api
 #CLIENT_SECRET: clientsecret

--- a/src/main/resources/application-mocking.yml
+++ b/src/main/resources/application-mocking.yml
@@ -13,6 +13,9 @@ services:
   athena:
     database: historic_api_mart_integration
     output: fake_bucket
+  athena-roles:
+    restricted: fakeIAM
+    general: fakeIAM2
 
 CLIENT_ID: hmpps-electronic-monitoring-datastore-api
 CLIENT_SECRET: clientsecret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,3 +61,6 @@ services:
   athena:
     database: ${ATHENA_DATABASE_NAME}
     output: ${ATHENA_OUTPUT_BUCKET}
+  athena-roles:
+    restricted: ${ATHENA_SPECIALS_IAM_ROLE}
+    general: ${ATHENA_GENERAL_IAM_ROLE}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/AmOrderDetailsRepositoryTest.kt
@@ -76,7 +76,7 @@ class AmOrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getAmOrderDetails("123", AthenaRole.DEV)
+      repository.getAmOrderDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -87,7 +87,7 @@ class AmOrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getAmOrderDetails("123", AthenaRole.DEV)
+      val result = repository.getAmOrderDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(AthenaAmOrderDetailsDTO::class.java)
     }
@@ -99,7 +99,7 @@ class AmOrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getAmOrderDetails(orderId, AthenaRole.DEV)
+      val result = repository.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.legacySubjectId).isEqualTo(orderId)
@@ -110,7 +110,7 @@ class AmOrderDetailsRepositoryTest {
       val dangerousInput = "123 OR 1=1"
 
       Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-        repository.getAmOrderDetails(dangerousInput, AthenaRole.DEV)
+        repository.getAmOrderDetails(dangerousInput, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
       }.withMessage("Input contains illegal characters")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/CurfewTimetableRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/CurfewTimetableRepositoryTest.kt
@@ -105,7 +105,7 @@ class CurfewTimetableRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getCurfewTimetable("123", AthenaRole.DEV)
+      repository.getCurfewTimetable("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -116,7 +116,7 @@ class CurfewTimetableRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getCurfewTimetable("123", AthenaRole.DEV)
+      val result = repository.getCurfewTimetable("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -127,7 +127,7 @@ class CurfewTimetableRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getCurfewTimetable("987", AthenaRole.DEV)
+      val result = repository.getCurfewTimetable("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/EquipmentDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/EquipmentDetailsRepositoryTest.kt
@@ -90,7 +90,7 @@ class EquipmentDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getEquipmentDetails("123", AthenaRole.DEV)
+      repository.getEquipmentDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -101,7 +101,7 @@ class EquipmentDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getEquipmentDetails("123", AthenaRole.DEV)
+      val result = repository.getEquipmentDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -112,7 +112,7 @@ class EquipmentDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getEquipmentDetails("987", AthenaRole.DEV)
+      val result = repository.getEquipmentDetails("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderDetailsRepositoryTest.kt
@@ -76,7 +76,7 @@ class OrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getOrderDetails("123", AthenaRole.DEV)
+      repository.getOrderDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -87,7 +87,7 @@ class OrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getOrderDetails("123", AthenaRole.DEV)
+      val result = repository.getOrderDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(AthenaOrderDetailsDTO::class.java)
     }
@@ -99,7 +99,7 @@ class OrderDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getOrderDetails(orderId, AthenaRole.DEV)
+      val result = repository.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.legacySubjectId).isEqualTo(orderId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderEventsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderEventsRepositoryTest.kt
@@ -78,7 +78,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getMonitoringEventsList("123", AthenaRole.DEV)
+      repository.getMonitoringEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -89,7 +89,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getMonitoringEventsList("123", AthenaRole.DEV)
+      val result = repository.getMonitoringEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -100,7 +100,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getMonitoringEventsList("987", AthenaRole.DEV)
+      val result = repository.getMonitoringEventsList("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)
@@ -146,7 +146,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getIncidentEventsList("123", AthenaRole.DEV)
+      repository.getIncidentEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -157,7 +157,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getIncidentEventsList("123", AthenaRole.DEV)
+      val result = repository.getIncidentEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -168,7 +168,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getIncidentEventsList("987", AthenaRole.DEV)
+      val result = repository.getIncidentEventsList("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)
@@ -265,7 +265,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getViolationEventsList("123", AthenaRole.DEV)
+      repository.getViolationEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -276,7 +276,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getViolationEventsList("123", AthenaRole.DEV)
+      val result = repository.getViolationEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -287,7 +287,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getViolationEventsList("987", AthenaRole.DEV)
+      val result = repository.getViolationEventsList("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)
@@ -351,7 +351,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getContactEventsList("123", AthenaRole.DEV)
+      repository.getContactEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -362,7 +362,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getContactEventsList("123", AthenaRole.DEV)
+      val result = repository.getContactEventsList("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -373,7 +373,7 @@ class OrderEventsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getContactEventsList("987", AthenaRole.DEV)
+      val result = repository.getContactEventsList("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderInformationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderInformationRepositoryTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athen
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena.AthenaSubjectHistoryReportDTO
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.metaDataRow
-import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.varCharValueColumn
 import java.util.UUID
 
 class OrderInformationRepositoryTest {
@@ -105,7 +104,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getKeyOrderInformation("123", AthenaRole.DEV)
+      repository.getKeyOrderInformation("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -116,7 +115,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getKeyOrderInformation("123", AthenaRole.DEV)
+      val result = repository.getKeyOrderInformation("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(AthenaKeyOrderInformationDTO::class.java)
     }
@@ -130,7 +129,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getKeyOrderInformation(orderId, AthenaRole.DEV)
+      val result = repository.getKeyOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.legacyOrderId).isEqualTo(orderId)
@@ -187,7 +186,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getSubjectHistoryReport("123", AthenaRole.DEV)
+      repository.getSubjectHistoryReport("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -198,7 +197,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getSubjectHistoryReport("123", AthenaRole.DEV)
+      val result = repository.getSubjectHistoryReport("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(AthenaSubjectHistoryReportDTO::class.java)
     }
@@ -212,7 +211,7 @@ class OrderInformationRepositoryTest {
 
       `when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getSubjectHistoryReport(orderId, AthenaRole.DEV)
+      val result = repository.getSubjectHistoryReport(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.name).isEqualTo(fullName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SuspensionOfVisitsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SuspensionOfVisitsRepositoryTest.kt
@@ -89,7 +89,7 @@ class SuspensionOfVisitsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getSuspensionOfVisits("123", AthenaRole.DEV)
+      repository.getSuspensionOfVisits("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -100,7 +100,7 @@ class SuspensionOfVisitsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getSuspensionOfVisits("123", AthenaRole.DEV)
+      val result = repository.getSuspensionOfVisits("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -111,7 +111,7 @@ class SuspensionOfVisitsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getSuspensionOfVisits("987", AthenaRole.DEV)
+      val result = repository.getSuspensionOfVisits("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)
@@ -126,7 +126,7 @@ class SuspensionOfVisitsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getSuspensionOfVisits("987", AthenaRole.DEV)
+      val result = repository.getSuspensionOfVisits("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/VisitDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/VisitDetailsRepositoryTest.kt
@@ -87,7 +87,7 @@ class VisitDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      repository.getVisitDetails("123", AthenaRole.DEV)
+      repository.getVisitDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Mockito.verify(emDatastoreClient).getQueryResult(any<AthenaQuery>(), any<AthenaRole>())
     }
@@ -98,7 +98,7 @@ class VisitDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getVisitDetails("123", AthenaRole.DEV)
+      val result = repository.getVisitDetails("123", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
@@ -109,7 +109,7 @@ class VisitDetailsRepositoryTest {
 
       Mockito.`when`(emDatastoreClient.getQueryResult(any<AthenaQuery>(), any<AthenaRole>())).thenReturn(resultSet)
 
-      val result = repository.getVisitDetails("987", AthenaRole.DEV)
+      val result = repository.getVisitDetails("987", AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/CurfewTimetableControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/CurfewTimetableControllerTest.kt
@@ -32,7 +32,7 @@ class CurfewTimetableControllerTest {
     Mockito.`when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     curfewTimetableService = Mockito.mock(CurfewTimetableService::class.java)
     roleService = Mockito.mock(AthenaRoleService::class.java)
-    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = Mockito.mock(AuditService::class.java)
     controller = CurfewTimetableController(curfewTimetableService, roleService, auditService)
   }
@@ -64,14 +64,14 @@ class CurfewTimetableControllerTest {
         ),
       )
 
-      Mockito.`when`(curfewTimetableService.getCurfewTimetable(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      Mockito.`when`(curfewTimetableService.getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getCurfewTimetable(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(curfewTimetableService, Mockito.times(1)).getCurfewTimetable(orderId, AthenaRole.DEV)
+      Mockito.verify(curfewTimetableService, Mockito.times(1)).getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/EquipmentDetailsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/EquipmentDetailsControllerTest.kt
@@ -33,7 +33,7 @@ class EquipmentDetailsControllerTest {
     Mockito.`when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     equipmentDetailsService = Mockito.mock(EquipmentDetailsService::class.java)
     roleService = Mockito.mock(AthenaRoleService::class.java)
-    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = Mockito.mock(AuditService::class.java)
     controller = EquipmentDetailsController(equipmentDetailsService, roleService, auditService)
   }
@@ -62,14 +62,14 @@ class EquipmentDetailsControllerTest {
         ),
       )
 
-      Mockito.`when`(equipmentDetailsService.getEquipmentDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      Mockito.`when`(equipmentDetailsService.getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getEquipmentDetails(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(equipmentDetailsService, Mockito.times(1)).getEquipmentDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(equipmentDetailsService, Mockito.times(1)).getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/OrderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/OrderControllerTest.kt
@@ -42,7 +42,7 @@ class OrderControllerTest {
     orderService = mock(OrderService::class.java)
     amOrderService = mock(AmOrderService::class.java)
     roleService = mock(AthenaRoleService::class.java)
-    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = mock(AuditService::class.java)
     controller = OrderController(orderService, amOrderService, roleService, auditService)
   }
@@ -76,14 +76,14 @@ class OrderControllerTest {
         documents = listOf<Document>(),
       )
 
-      `when`(orderService.getOrderInformation(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderService.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getSpecialsOrder(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderService, times(1)).getOrderInformation(orderId, AthenaRole.DEV)
+      Mockito.verify(orderService, times(1)).getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -116,7 +116,7 @@ class OrderControllerTest {
         documents = listOf<Document>(),
       )
 
-      `when`(orderService.getOrderInformation(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderService.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getOrderSummary(authentication, orderId)
 
@@ -124,7 +124,7 @@ class OrderControllerTest {
       Assertions.assertThat(result.body).isNotNull
       Assertions.assertThat(result.body).isInstanceOf(OrderInformation::class.java)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
-      Mockito.verify(orderService, times(1)).getOrderInformation(orderId, AthenaRole.DEV)
+      Mockito.verify(orderService, times(1)).getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -140,7 +140,7 @@ class OrderControllerTest {
         offenceRisk = false,
       )
 
-      `when`(orderService.getOrderDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderService.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getOrderDetails(authentication, orderId)
 
@@ -159,14 +159,14 @@ class OrderControllerTest {
         offenceRisk = false,
       )
 
-      `when`(orderService.getOrderDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderService.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getOrderDetails(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderService, times(1)).getOrderDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(orderService, times(1)).getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -182,7 +182,7 @@ class OrderControllerTest {
         responsibleOrgDetailsPhoneNumber = "07777777777",
       )
 
-      `when`(amOrderService.getAmOrderDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(amOrderService.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getAmOrderDetails(authentication, orderId)
 
@@ -201,14 +201,14 @@ class OrderControllerTest {
         responsibleOrgDetailsPhoneNumber = "07777777777",
       )
 
-      `when`(amOrderService.getAmOrderDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(amOrderService.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getAmOrderDetails(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(amOrderService, times(1)).getAmOrderDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(amOrderService, times(1)).getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/OrderEventsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/OrderEventsControllerTest.kt
@@ -38,7 +38,7 @@ class OrderEventsControllerTest {
     `when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     orderEventsService = Mockito.mock(OrderEventsService::class.java)
     roleService = mock(AthenaRoleService::class.java)
-    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = Mockito.mock(AuditService::class.java)
     controller = OrderEventsController(orderEventsService, roleService, auditService)
   }
@@ -61,14 +61,14 @@ class OrderEventsControllerTest {
         ),
       )
 
-      `when`(orderEventsService.getMonitoringEvents(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderEventsService.getMonitoringEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getMonitoringEvents(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderEventsService, Mockito.times(1)).getMonitoringEvents(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsService, Mockito.times(1)).getMonitoringEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -89,14 +89,14 @@ class OrderEventsControllerTest {
         ),
       )
 
-      `when`(orderEventsService.getIncidentEvents(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderEventsService.getIncidentEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getIncidentEvents(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderEventsService, Mockito.times(1)).getIncidentEvents(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsService, Mockito.times(1)).getIncidentEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -132,14 +132,14 @@ class OrderEventsControllerTest {
         ),
       )
 
-      `when`(orderEventsService.getViolationEvents(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderEventsService.getViolationEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getViolationEvents(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderEventsService, Mockito.times(1)).getViolationEvents(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsService, Mockito.times(1)).getViolationEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 
@@ -166,14 +166,14 @@ class OrderEventsControllerTest {
         ),
       )
 
-      `when`(orderEventsService.getContactEvents(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderEventsService.getContactEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getContactEvents(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(orderEventsService, Mockito.times(1)).getContactEvents(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsService, Mockito.times(1)).getContactEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
@@ -37,8 +37,8 @@ class SearchControllerTest {
     `when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     orderService = mock(OrderService::class.java)
     roleService = mock(AthenaRoleService::class.java)
-    `when`(roleService.fromString(any<String>())).thenReturn(AthenaRole.DEV)
-    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    `when`(roleService.fromString(any<String>())).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
+    `when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = mock(AuditService::class.java)
     controller = SearchController(orderService, roleService, auditService)
   }
@@ -114,7 +114,7 @@ class SearchControllerTest {
       val queryObject = AthenaStringQuery(queryString)
       val queryResponse = "fake query response"
 
-      `when`(orderService.query(queryObject, AthenaRole.DEV)).thenReturn(queryResponse)
+      `when`(orderService.query(queryObject, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(queryResponse)
 
       val result = controller.queryAthena(authentication, queryObject, queryRole)
 
@@ -132,7 +132,7 @@ class SearchControllerTest {
       val queryObject = AthenaStringQuery(queryString)
       val errorMessage = "fake error message"
 
-      `when`(orderService.query(queryObject, AthenaRole.DEV)).thenThrow(NullPointerException(errorMessage))
+      `when`(orderService.query(queryObject, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenThrow(NullPointerException(errorMessage))
 
       val result = controller.queryAthena(authentication, queryObject, queryRole)
 
@@ -164,7 +164,7 @@ class SearchControllerTest {
         queryExecutionId = queryExecutionId,
       )
 
-      `when`(orderService.getQueryExecutionId(orderSearchCriteria, AthenaRole.DEV)).thenReturn(queryExecutionId)
+      `when`(orderService.getQueryExecutionId(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(queryExecutionId)
 
       val result = controller.searchOrders(authentication, orderSearchCriteria)
 
@@ -195,7 +195,7 @@ class SearchControllerTest {
         ),
       )
 
-      `when`(orderService.getSearchResults(queryExecutionId, AthenaRole.DEV)).thenReturn(expectedResult)
+      `when`(orderService.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getSearchResults(authentication, queryExecutionId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SuspensionOfVisitsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SuspensionOfVisitsControllerTest.kt
@@ -32,7 +32,7 @@ class SuspensionOfVisitsControllerTest {
     Mockito.`when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     suspensionOfVisitsService = Mockito.mock(SuspensionOfVisitsService::class.java)
     roleService = Mockito.mock(AthenaRoleService::class.java)
-    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = Mockito.mock(AuditService::class.java)
     controller = SuspensionOfVisitsController(suspensionOfVisitsService, roleService, auditService)
   }
@@ -53,14 +53,14 @@ class SuspensionOfVisitsControllerTest {
         ),
       )
 
-      Mockito.`when`(suspensionOfVisitsService.getSuspensionOfVisits(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      Mockito.`when`(suspensionOfVisitsService.getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getSuspensionOfVisits(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(suspensionOfVisitsService, Mockito.times(1)).getSuspensionOfVisits(orderId, AthenaRole.DEV)
+      Mockito.verify(suspensionOfVisitsService, Mockito.times(1)).getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/VisitDetailsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/VisitDetailsControllerTest.kt
@@ -33,7 +33,7 @@ class VisitDetailsControllerTest {
     Mockito.`when`(authentication.name).thenReturn("MOCK_AUTH_USER")
     visitDetailsService = Mockito.mock(VisitDetailsService::class.java)
     roleService = Mockito.mock(AthenaRoleService::class.java)
-    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.DEV)
+    Mockito.`when`(roleService.getRoleFromAuthentication(authentication)).thenReturn(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     auditService = Mockito.mock(AuditService::class.java)
     controller = VisitDetailsController(visitDetailsService, roleService, auditService)
   }
@@ -62,14 +62,14 @@ class VisitDetailsControllerTest {
         ),
       )
 
-      Mockito.`when`(visitDetailsService.getVisitDetails(orderId, AthenaRole.DEV)).thenReturn(expectedResult)
+      Mockito.`when`(visitDetailsService.getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(expectedResult)
 
       val result = controller.getVisitDetails(authentication, orderId)
 
       Assertions.assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
       Assertions.assertThat(result.body).isEqualTo(expectedResult)
 
-      Mockito.verify(visitDetailsService, Mockito.times(1)).getVisitDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(visitDetailsService, Mockito.times(1)).getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AmOrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AmOrderServiceTest.kt
@@ -41,26 +41,26 @@ class AmOrderServiceTest {
 
     @BeforeEach
     fun setup() {
-      `when`(amOrderDetailsRepository.getAmOrderDetails(orderId, AthenaRole.DEV))
+      `when`(amOrderDetailsRepository.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(blankOrderDetails)
     }
 
     @Test
     fun `calls getAmOrderDetails from order details repository`() {
-      service.getAmOrderDetails(orderId, AthenaRole.DEV)
-      Mockito.verify(amOrderDetailsRepository, times(1)).getAmOrderDetails(orderId, AthenaRole.DEV)
+      service.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
+      Mockito.verify(amOrderDetailsRepository, times(1)).getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns AmOrderDetails`() {
-      val result = service.getAmOrderDetails(orderId, AthenaRole.DEV)
+      val result = service.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(AmOrderDetails::class.java)
     }
 
     @Test
     fun `returns correct details of the order`() {
-      val result = service.getAmOrderDetails(orderId, AthenaRole.DEV)
+      val result = service.getAmOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.legacySubjectId).isEqualTo("")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
@@ -11,10 +11,15 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.A
 
 class AthenaRoleServiceTest {
   private lateinit var athenaRoleService: AthenaRoleService
+  private val restrictedRoleIamString = "fake:iam:restricted"
+  private val generalRoleIamString = "fake:iam:restricted"
 
   @BeforeEach
   fun setUp() {
-    athenaRoleService = AthenaRoleService()
+    athenaRoleService = AthenaRoleService(
+      restrictedRoleIamString,
+      generalRoleIamString,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
@@ -4,7 +4,10 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.client.AthenaRole
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AthenaRoleService
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.AuthenticationStub
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils.AuthorityStub
 
 class AthenaRoleServiceTest {
   private lateinit var athenaRoleService: AthenaRoleService
@@ -21,9 +24,44 @@ class AthenaRoleServiceTest {
 
   @Nested
   inner class GetRoleFromAuthentication {
+
     // when they have no role in the Authentication object, give them NONE
+    @Test
+    fun `GetRoleFromAuthentication returns role NONE if no authorities present`() {
+      val auth = AuthenticationStub(
+        name = "fake name",
+        authorities = mutableListOf(),
+      )
+
+      val result: AthenaRole = athenaRoleService.getRoleFromAuthentication(auth)
+
+      Assertions.assertThat(result).isEqualTo(AthenaRole.NONE)
+    }
+
+    @Test
+    fun `GetRoleFromAuthentication returns role NONE if wrong authorities present`() {
+      val auth = AuthenticationStub(
+        name = "fake name",
+        authorities = mutableListOf(AuthorityStub("ROLE_FOR_OTHER_SERVICE")),
+      )
+
+      val result: AthenaRole = athenaRoleService.getRoleFromAuthentication(auth)
+
+      Assertions.assertThat(result).isEqualTo(AthenaRole.NONE)
+    }
 
     // when they have General, as an authority/claim, give them general
+    @Test
+    fun `GetRoleFromAuthentication returns role ROLE_EM_DATASTORE_GENERAL_RO if this role is present`() {
+      val auth = AuthenticationStub(
+        name = "fake name",
+        authorities = mutableListOf(AuthorityStub("ROLE_EM_DATASTORE_GENERAL_RO")),
+      )
+
+      val result: AthenaRole = athenaRoleService.getRoleFromAuthentication(auth)
+
+      Assertions.assertThat(result).isEqualTo(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
+    }
 
     // when special, give them special not general
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
@@ -28,6 +28,27 @@ class AthenaRoleServiceTest {
   }
 
   @Nested
+  inner class GetIamRole {
+    @Test
+    fun `retrieves IAM role for NONE Athena role`() {
+      val result: String = athenaRoleService.getIamRole(AthenaRole.NONE)
+      Assertions.assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `retrieves IAM role for GENERAL Athena role`() {
+      val result: String = athenaRoleService.getIamRole(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
+      Assertions.assertThat(result).isEqualTo(generalRoleIamString)
+    }
+
+    @Test
+    fun `retrieves IAM role for RESTRICTED Athena role`() {
+      val result: String = athenaRoleService.getIamRole(AthenaRole.ROLE_EM_DATASTORE_RESTRICTED_RO)
+      Assertions.assertThat(result).isEqualTo(restrictedRoleIamString)
+    }
+  }
+
+  @Nested
   inner class MapToOrderedUniqueRoles {
     @Test
     fun `de-duplicates identical elements`() {
@@ -86,16 +107,16 @@ class AthenaRoleServiceTest {
     // when they have General, as an authority/claim, give them general
     @Test
     fun `GetRoleFromAuthentication returns role ROLE_EM_DATASTORE_GENERAL_RO with correct IAM role if this role is present`() {
-      val expectedRole = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
       val auth = AuthenticationStub(
         name = "fake name",
         authorities = mutableListOf(AuthorityStub("ROLE_EM_DATASTORE_GENERAL_RO")),
       )
 
       val result: AthenaRole = athenaRoleService.getRoleFromAuthentication(auth)
+      val resolvedIamRole = athenaRoleService.getIamRole(result)
 
       Assertions.assertThat(result).isEqualTo(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
-      Assertions.assertThat(result.iamRole).isEqualTo(expectedRole)
+      Assertions.assertThat(resolvedIamRole).isEqualTo(generalRoleIamString)
     }
 
     @Test
@@ -117,16 +138,16 @@ class AthenaRoleServiceTest {
     // when special, give them special not general
     @Test
     fun `GetRoleFromAuthentication returns role ROLE_EM_DATASTORE_RESTRICTED_RO if this role is present`() {
-      val expectedRole = "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
       val auth = AuthenticationStub(
         name = "fake name",
         authorities = mutableListOf(AuthorityStub("ROLE_EM_DATASTORE_RESTRICTED_RO")),
       )
 
       val result: AthenaRole = athenaRoleService.getRoleFromAuthentication(auth)
+      val resolvedIamRole = athenaRoleService.getIamRole(result)
 
       Assertions.assertThat(result).isEqualTo(AthenaRole.ROLE_EM_DATASTORE_RESTRICTED_RO)
-      Assertions.assertThat(result.iamRole).isEqualTo(expectedRole)
+      Assertions.assertThat(resolvedIamRole).isEqualTo(restrictedRoleIamString)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/AthenaRoleServiceTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.services
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.service.AthenaRoleService
+
+class AthenaRoleServiceTest {
+  private lateinit var athenaRoleService: AthenaRoleService
+
+  @BeforeEach
+  fun setUp() {
+    athenaRoleService = AthenaRoleService()
+  }
+
+  @Test
+  fun `AthenaRoleService can be instantiated`() {
+    Assertions.assertThat(athenaRoleService).isNotNull()
+  }
+
+  @Nested
+  inner class GetRoleFromAuthentication {
+    // when they have no role in the Authentication object, give them NONE
+
+    // when they have General, as an authority/claim, give them general
+
+    // when special, give them special not general
+
+    // when special and general, then special
+  }
+
+  @Nested
+  inner class FomString {
+    // return the role with name matching NONE
+
+    // return the role with name matching GENERAL
+
+    // return the role with name matching RESTRICTED
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/CurfewTimetableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/CurfewTimetableServiceTest.kt
@@ -57,27 +57,27 @@ class CurfewTimetableServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(curfewTimetableRepository.getCurfewTimetable(orderId, AthenaRole.DEV))
+      Mockito.`when`(curfewTimetableRepository.getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleCurfewTimetable)
     }
 
     @Test
     fun `calls getCurfewTimetable from order information repository`() {
-      service.getCurfewTimetable(orderId, AthenaRole.DEV)
+      service.getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(curfewTimetableRepository, Mockito.times(1)).getCurfewTimetable(orderId, AthenaRole.DEV)
+      Mockito.verify(curfewTimetableRepository, Mockito.times(1)).getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns a list of CurfewTimetable when a response is received`() {
-      var result = service.getCurfewTimetable(orderId, AthenaRole.DEV)
+      var result = service.getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the CurfewTimetable when a response is received`() {
-      var result = service.getCurfewTimetable(orderId, AthenaRole.DEV)
+      var result = service.getCurfewTimetable(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/EquipmentDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/EquipmentDetailsServiceTest.kt
@@ -53,27 +53,27 @@ class EquipmentDetailsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(equipmentDetailsRepository.getEquipmentDetails(orderId, AthenaRole.DEV))
+      Mockito.`when`(equipmentDetailsRepository.getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleEquipmentDetailsList)
     }
 
     @Test
     fun `calls getEquipmentDetails from order information repository`() {
-      service.getEquipmentDetails(orderId, AthenaRole.DEV)
+      service.getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(equipmentDetailsRepository, Mockito.times(1)).getEquipmentDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(equipmentDetailsRepository, Mockito.times(1)).getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns a list of EquipmentDetails when a response is received`() {
-      var result = service.getEquipmentDetails(orderId, AthenaRole.DEV)
+      var result = service.getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the EquipmentDetails when a response is received`() {
-      var result = service.getEquipmentDetails(orderId, AthenaRole.DEV)
+      var result = service.getEquipmentDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderEventsServiceTest.kt
@@ -54,27 +54,27 @@ class OrderEventsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(orderEventsRepository.getMonitoringEventsList(orderId, AthenaRole.DEV))
+      Mockito.`when`(orderEventsRepository.getMonitoringEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleMonitoringEventList)
     }
 
     @Test
     fun `calls getMonitoringEventsList from order information repository`() {
-      service.getMonitoringEvents(orderId, AthenaRole.DEV)
+      service.getMonitoringEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderEventsRepository, Mockito.times(1)).getMonitoringEventsList(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsRepository, Mockito.times(1)).getMonitoringEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns MonitoringEventList when a response is received`() {
-      var result = service.getMonitoringEvents(orderId, AthenaRole.DEV)
+      var result = service.getMonitoringEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the order when a response is received`() {
-      var result = service.getMonitoringEvents(orderId, AthenaRole.DEV)
+      var result = service.getMonitoringEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)
@@ -103,27 +103,27 @@ class OrderEventsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(orderEventsRepository.getIncidentEventsList(orderId, AthenaRole.DEV))
+      Mockito.`when`(orderEventsRepository.getIncidentEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleIncidentEventList)
     }
 
     @Test
     fun `calls getIncidentEventsList from order information repository`() {
-      service.getIncidentEvents(orderId, AthenaRole.DEV)
+      service.getIncidentEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderEventsRepository, Mockito.times(1)).getIncidentEventsList(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsRepository, Mockito.times(1)).getIncidentEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns IncidentEventList when a response is received`() {
-      var result = service.getIncidentEvents(orderId, AthenaRole.DEV)
+      var result = service.getIncidentEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the order when a response is received`() {
-      var result = service.getIncidentEvents(orderId, AthenaRole.DEV)
+      var result = service.getIncidentEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)
@@ -169,27 +169,27 @@ class OrderEventsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(orderEventsRepository.getViolationEventsList(orderId, AthenaRole.DEV))
+      Mockito.`when`(orderEventsRepository.getViolationEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleViolationEventList)
     }
 
     @Test
     fun `calls getViolationEventsList from order information repository`() {
-      service.getViolationEvents(orderId, AthenaRole.DEV)
+      service.getViolationEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderEventsRepository, Mockito.times(1)).getViolationEventsList(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsRepository, Mockito.times(1)).getViolationEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns ViolationEventList when a response is received`() {
-      var result = service.getViolationEvents(orderId, AthenaRole.DEV)
+      var result = service.getViolationEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the order when a response is received`() {
-      var result = service.getViolationEvents(orderId, AthenaRole.DEV)
+      var result = service.getViolationEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)
@@ -225,27 +225,27 @@ class OrderEventsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(orderEventsRepository.getContactEventsList(orderId, AthenaRole.DEV))
+      Mockito.`when`(orderEventsRepository.getContactEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleContactEventList)
     }
 
     @Test
     fun `calls getContactEventsList from order information repository`() {
-      service.getContactEvents(orderId, AthenaRole.DEV)
+      service.getContactEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderEventsRepository, Mockito.times(1)).getContactEventsList(orderId, AthenaRole.DEV)
+      Mockito.verify(orderEventsRepository, Mockito.times(1)).getContactEventsList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns ContactsEventList when a response is received`() {
-      var result = service.getContactEvents(orderId, AthenaRole.DEV)
+      var result = service.getContactEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the order when a response is received`() {
-      var result = service.getContactEvents(orderId, AthenaRole.DEV)
+      var result = service.getContactEvents(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
@@ -48,18 +48,18 @@ class OrderServiceTest {
   inner class CheckAvailability {
     @Test
     fun `calls listLegacyIds from order repository`() {
-      `when`(searchRepository.listLegacyIds(AthenaRole.DEV)).thenReturn(listOf<String>())
+      `when`(searchRepository.listLegacyIds(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(listOf<String>())
 
-      service.checkAvailability(AthenaRole.DEV)
+      service.checkAvailability(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(searchRepository, times(1)).listLegacyIds(AthenaRole.DEV)
+      Mockito.verify(searchRepository, times(1)).listLegacyIds(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `confirms AWS athena is available if successful`() {
-      `when`(searchRepository.listLegacyIds(AthenaRole.DEV)).thenReturn(listOf<String>())
+      `when`(searchRepository.listLegacyIds(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn(listOf<String>())
 
-      val result = service.checkAvailability(AthenaRole.DEV)
+      val result = service.checkAvailability(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isTrue
     }
@@ -68,9 +68,9 @@ class OrderServiceTest {
     fun `confirms AWS athena is unavailable if not successful`() {
       val errorMessage = "fake error message"
 
-      `when`(searchRepository.listLegacyIds(AthenaRole.DEV)).thenThrow(NullPointerException(errorMessage))
+      `when`(searchRepository.listLegacyIds(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenThrow(NullPointerException(errorMessage))
 
-      val result = service.checkAvailability(AthenaRole.DEV)
+      val result = service.checkAvailability(AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isFalse
     }
@@ -82,18 +82,18 @@ class OrderServiceTest {
 
     @Test
     fun `passes query to order repository`() {
-      `when`(searchRepository.runQuery(athenaQuery, AthenaRole.DEV)).thenReturn("Expected response")
+      `when`(searchRepository.runQuery(athenaQuery, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn("Expected response")
 
-      service.query(athenaQuery, AthenaRole.DEV)
+      service.query(athenaQuery, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(searchRepository, times(1)).runQuery(athenaQuery, AthenaRole.DEV)
+      Mockito.verify(searchRepository, times(1)).runQuery(athenaQuery, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns response from order repository`() {
-      `when`(searchRepository.runQuery(athenaQuery, AthenaRole.DEV)).thenReturn("Expected response")
+      `when`(searchRepository.runQuery(athenaQuery, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)).thenReturn("Expected response")
 
-      val result = service.query(athenaQuery, AthenaRole.DEV)
+      val result = service.query(athenaQuery, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isEqualTo("Expected response")
     }
@@ -107,21 +107,21 @@ class OrderServiceTest {
 
     @Test
     fun `calls searchOrders from order repository`() {
-      `when`(searchRepository.searchOrders(orderSearchCriteria, AthenaRole.DEV))
+      `when`(searchRepository.searchOrders(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn("query-execution-id")
 
-      service.getQueryExecutionId(orderSearchCriteria, AthenaRole.DEV)
+      service.getQueryExecutionId(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(searchRepository, times(1)).searchOrders(orderSearchCriteria, AthenaRole.DEV)
+      Mockito.verify(searchRepository, times(1)).searchOrders(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns a query execution ID`() {
       val expectedResult: String = "query-execution-id"
-      `when`(searchRepository.searchOrders(orderSearchCriteria, AthenaRole.DEV))
+      `when`(searchRepository.searchOrders(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn("query-execution-id")
 
-      val result = service.getQueryExecutionId(orderSearchCriteria, AthenaRole.DEV)
+      val result = service.getQueryExecutionId(orderSearchCriteria, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isEqualTo(expectedResult)
     }
@@ -133,20 +133,20 @@ class OrderServiceTest {
 
     @Test
     fun `calls searchOrders from order repository`() {
-      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.DEV))
+      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(listOf<AthenaOrderSearchResultDTO>())
 
-      service.getSearchResults(queryExecutionId, AthenaRole.DEV)
+      service.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(searchRepository, times(1)).getSearchResults(queryExecutionId, AthenaRole.DEV)
+      Mockito.verify(searchRepository, times(1)).getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns empty list when no results are returned`() {
-      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.DEV))
+      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(listOf<AthenaOrderSearchResultDTO>())
 
-      val result = service.getSearchResults(queryExecutionId, AthenaRole.DEV)
+      val result = service.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
       Assertions.assertThat(result.count()).isEqualTo(0)
@@ -154,7 +154,7 @@ class OrderServiceTest {
 
     @Test
     fun `returns list of order search results when results are returned`() {
-      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.DEV))
+      `when`(searchRepository.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(
           listOf<AthenaOrderSearchResultDTO>(
             AthenaOrderSearchResultDTO(
@@ -170,7 +170,7 @@ class OrderServiceTest {
           ),
         )
 
-      val result = service.getSearchResults(queryExecutionId, AthenaRole.DEV)
+      val result = service.getSearchResults(queryExecutionId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
       Assertions.assertThat(result.count()).isEqualTo(1)
@@ -207,47 +207,47 @@ class OrderServiceTest {
 
     @BeforeEach
     fun setup() {
-      `when`(orderInformationRepository.getKeyOrderInformation(orderId, AthenaRole.DEV))
+      `when`(orderInformationRepository.getKeyOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(blankKeyOrderInformation)
-      `when`(orderInformationRepository.getSubjectHistoryReport(orderId, AthenaRole.DEV))
+      `when`(orderInformationRepository.getSubjectHistoryReport(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(blankSubjectHistoryReport)
-      `when`(orderInformationRepository.getDocumentList(orderId, AthenaRole.DEV))
+      `when`(orderInformationRepository.getDocumentList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(blankDocumentList)
     }
 
     @Test
     fun `calls getKeyOrderInformation from order information repository`() {
-      service.getOrderInformation(orderId, AthenaRole.DEV)
+      service.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderInformationRepository, times(1)).getKeyOrderInformation(orderId, AthenaRole.DEV)
+      Mockito.verify(orderInformationRepository, times(1)).getKeyOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Disabled("SubjectHistoryReport will no longer be used")
     @Test
     fun `calls getSubjectHistoryReport from order information repository`() {
-      service.getOrderInformation(orderId, AthenaRole.DEV)
+      service.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderInformationRepository, times(1)).getSubjectHistoryReport(orderId, AthenaRole.DEV)
+      Mockito.verify(orderInformationRepository, times(1)).getSubjectHistoryReport(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Disabled("We are not currently returning documents")
     @Test
     fun `calls getDocumentList from order information repository`() {
-      service.getOrderInformation(orderId, AthenaRole.DEV)
+      service.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(orderInformationRepository, times(1)).getDocumentList(orderId, AthenaRole.DEV)
+      Mockito.verify(orderInformationRepository, times(1)).getDocumentList(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns OrderInformation when a document is found`() {
-      val result = service.getOrderInformation(orderId, AthenaRole.DEV)
+      val result = service.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(OrderInformation::class.java)
     }
 
     @Test
     fun `returns correct details of the order when a document is found`() {
-      val result = service.getOrderInformation(orderId, AthenaRole.DEV)
+      val result = service.getOrderInformation(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.keyOrderInformation.legacyOrderId).isEqualTo(orderId)
@@ -269,26 +269,26 @@ class OrderServiceTest {
 
     @BeforeEach
     fun setup() {
-      `when`(orderDetailsRepository.getOrderDetails(orderId, AthenaRole.DEV))
+      `when`(orderDetailsRepository.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(blankOrderDetails)
     }
 
     @Test
     fun `calls getOrderDetails from order details repository`() {
-      service.getOrderDetails(orderId, AthenaRole.DEV)
-      Mockito.verify(orderDetailsRepository, times(1)).getOrderDetails(orderId, AthenaRole.DEV)
+      service.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
+      Mockito.verify(orderDetailsRepository, times(1)).getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns OrderDetails`() {
-      val result = service.getOrderDetails(orderId, AthenaRole.DEV)
+      val result = service.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(OrderDetails::class.java)
     }
 
     @Test
     fun `returns correct details of the order`() {
-      val result = service.getOrderDetails(orderId, AthenaRole.DEV)
+      val result = service.getOrderDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.legacySubjectId).isEqualTo("")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/SuspensionOfVisitsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/SuspensionOfVisitsServiceTest.kt
@@ -44,27 +44,27 @@ class SuspensionOfVisitsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(suspensionOfVisitsRepository.getSuspensionOfVisits(orderId, AthenaRole.DEV))
+      Mockito.`when`(suspensionOfVisitsRepository.getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleSuspensionOfVisits)
     }
 
     @Test
     fun `calls getSuspensionOfVisits from order information repository`() {
-      service.getSuspensionOfVisits(orderId, AthenaRole.DEV)
+      service.getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(suspensionOfVisitsRepository, Mockito.times(1)).getSuspensionOfVisits(orderId, AthenaRole.DEV)
+      Mockito.verify(suspensionOfVisitsRepository, Mockito.times(1)).getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns a list of SuspensionOfVisits when a response is received`() {
-      var result = service.getSuspensionOfVisits(orderId, AthenaRole.DEV)
+      var result = service.getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the CurfewTimetable when a response is received`() {
-      var result = service.getSuspensionOfVisits(orderId, AthenaRole.DEV)
+      var result = service.getSuspensionOfVisits(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/VisitDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/VisitDetailsServiceTest.kt
@@ -52,27 +52,27 @@ class VisitDetailsServiceTest {
 
     @BeforeEach
     fun setup() {
-      Mockito.`when`(visitDetailsRepository.getVisitDetails(orderId, AthenaRole.DEV))
+      Mockito.`when`(visitDetailsRepository.getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO))
         .thenReturn(exampleVisitDetails)
     }
 
     @Test
     fun `calls getVisitDetails from order information repository`() {
-      service.getVisitDetails(orderId, AthenaRole.DEV)
+      service.getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
-      Mockito.verify(visitDetailsRepository, Mockito.times(1)).getVisitDetails(orderId, AthenaRole.DEV)
+      Mockito.verify(visitDetailsRepository, Mockito.times(1)).getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
     }
 
     @Test
     fun `returns a list of VisitDetails when a response is received`() {
-      var result = service.getVisitDetails(orderId, AthenaRole.DEV)
+      var result = service.getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isInstanceOf(List::class.java)
     }
 
     @Test
     fun `returns correct details of the VisitDetails when a response is received`() {
-      var result = service.getVisitDetails(orderId, AthenaRole.DEV)
+      var result = service.getVisitDetails(orderId, AthenaRole.ROLE_EM_DATASTORE_GENERAL_RO)
 
       Assertions.assertThat(result).isNotNull
       Assertions.assertThat(result.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/testutils/AuthenticationStub.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/testutils/AuthenticationStub.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+
+class AuthenticationStub(
+  private val name: String? = null,
+  private val authorities: MutableCollection<out GrantedAuthority> = mutableListOf(),
+) : Authentication {
+  override fun getName(): String = name ?: ""
+  override fun getAuthorities(): MutableCollection<out GrantedAuthority> = authorities
+  override fun isAuthenticated(): Boolean = false
+  override fun getCredentials(): Any? = null
+  override fun getDetails(): Any = ""
+  override fun getPrincipal(): Any = ""
+  override fun setAuthenticated(isAuthenticated: Boolean) {}
+}
+
+class AuthenticationStubTest {
+
+  @Test
+  fun `AuthenticationStub can be instantiated with passed name value`() {
+    val nameValue = "fake name"
+    val localStub = AuthenticationStub(nameValue)
+    Assertions.assertThat(localStub.name).isEqualTo(nameValue)
+  }
+
+  @Test
+  fun `AuthenticationStub can be instantiated with passed Authorities`() {
+    val authorityName = "fake authority"
+    val authority: GrantedAuthority = AuthorityStub(authorityName)
+    val authoritiesList = mutableListOf(authority)
+    val localStub = AuthenticationStub(authorities = authoritiesList)
+    Assertions.assertThat(localStub.authorities).isEqualTo(authoritiesList)
+  }
+
+  @Test
+  fun `AuthenticationStub can be instantiated with passed name and authorities`() {
+    val nameValue = "fake name"
+    val authority1Name = "fake authority 1"
+    val authority2Name = "fake authority 2"
+    val authoritiesList = mutableListOf(
+      AuthorityStub(authority1Name),
+      AuthorityStub(authority2Name),
+    )
+
+    val localStub = AuthenticationStub(
+      name = nameValue,
+      authorities = authoritiesList,
+    )
+
+    Assertions.assertThat(localStub.name).isEqualTo(nameValue)
+    Assertions.assertThat(localStub.authorities).isEqualTo(authoritiesList)
+    Assertions.assertThat(localStub.authorities.first().authority).isEqualTo(authority1Name)
+    Assertions.assertThat(localStub.authorities.last().authority).isEqualTo(authority2Name)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/testutils/AuthorityStub.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/testutils/AuthorityStub.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.testutils
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.GrantedAuthority
+
+class AuthorityStub(
+  private val authorityString: String,
+) : GrantedAuthority {
+  override fun getAuthority(): String = authorityString
+}
+
+class AuthorityStubTest {
+  @Test
+  fun `AuthorityStub can be instantiated with an authority string`() {
+    val fakeClaimString = "FAKE_AUTHORITY_VALUE"
+    val authorityStub = AuthorityStub(fakeClaimString)
+    Assertions.assertThat(authorityStub.authority).isEqualTo(fakeClaimString)
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,3 +24,6 @@ services:
   athena:
     database: totally-fake-database-name
     output: totally-fake-output-bucket-name
+  athena-roles:
+    restricted: fakeIAM
+    general: fakeIAM2


### PR DESCRIPTION
Role assignment is (at last!) aligned with the authorities provided by the jwt token
- Users will now receive a role based on these claims
- The role they receive is based on a priority ordering in the AthenaRole.kt enum:
  - If they have `ROLE_EM_DATASTORE_RESTRICTED_RO` they get the specials iam role (even if they also have other roles)
  - If they have `ROLE_EM_DATASTORE_GENERAL_RO` they get the normal iam role
  - If they have neither role they get a `NONE` role with no IAM set (This should not happen as all our users are authenticated)
- The `DEV` role is now fully replaced with `ROLE_EM_DATASTORE_GENERAL_RO`

Additions to this PR:
- [IAM roles are now pulled through from application config and helm into the AthenaRoleService](https://github.com/ministryofjustice/hmpps-electronic-monitoring-datastore-api/pull/92/commits/5126048a7362fef131f30665a00b85174b90a495)
- [IAM roles are now provided from app config by AthenaRoleService.getIamRole(AthenaRole): String instead of being held in the AthenaRole enum](https://github.com/ministryofjustice/hmpps-electronic-monitoring-datastore-api/pull/92/commits/17a085fb1f152a81674d4271685fba84a2f5e779)

**NOW** we should be able to set our Athena IAM roles in our environment variables, and have them pull through to the app.

Note that all of them are currently set to point at TEST - but, we should be able to repoint to different Athena accounts and databases just with config changes from now on.