### PR TITLE
Order search: Allow empty legacySubjectId

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
@@ -12,7 +12,7 @@ class OrderSearchQueryBuilder(
 
   var legacySubjectId: String? = null
     private set(value) {
-      if (value == null) {
+      if (value.isNullOrEmpty()) {
         return
       }
 


### PR DESCRIPTION
The order search query builder now accepts an empty string for the legacySubjectId.
Previously it did not, which caused errors when submitting a search if legacySubjectId was not populated in the UI.