### PR TITLE
Define prod service account name

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,8 +2,11 @@
 # Per environment values which override defaults in hmpps-electronic-monitoring-datastore-api/values.yaml
 
 generic-service:
+  serviceAccountName: "hmpps-em-datastore-prod-athena"
+
   ingress:
     host: electronic-monitoring-datastore-api.hmpps.service.justice.gov.uk
+
 
   env:
 #    SENTRY_ENV: prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,7 +7,6 @@ generic-service:
   ingress:
     host: electronic-monitoring-datastore-api.hmpps.service.justice.gov.uk
 
-
   env:
 #    SENTRY_ENV: prod
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json


### PR DESCRIPTION
Define the service account name for the production environment.
We think this will resolve [these audit logging errors](https://madetechteam.slack.com/archives/C069RF589V4/p1742199261066459).