### PR TITLE
Alcohol Monitoring order search path

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelper.kt
@@ -114,5 +114,11 @@ class AthenaHelper {
         mapper.convertValue(row, T::class.java)
       }
     }
+
+    fun tableNameFromSearchType(searchType: String): String = when (searchType.lowercase()) {
+      "integrity" -> "order_details"
+      "alcohol-monitoring" -> "am_order_details"
+      else -> throw IllegalArgumentException("Unknown search type: $searchType")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
@@ -13,7 +13,8 @@ class OrderSearchQueryBuilder(
   arrayOf(
     "legacy_subject_id",
     "legacy_order_id",
-    "full_name",
+    "first_name",
+    "last_name",
     "alias",
     "date_of_birth",
     "primary_address_line_1",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
@@ -32,8 +32,8 @@ class OrderSearchQueryBuilder(
       return this
     }
 
-    values.add(value)
-    whereClauses.put("legacy_subject_id", "legacy_subject_id" eq value)
+    values.add("UPPER('%$value%')")
+    whereClauses.put("legacy_subject_id", "legacy_subject_id" eq "UPPER('%$value%')")
     return this
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
@@ -7,9 +7,10 @@ import java.time.LocalDate
 
 class OrderSearchQueryBuilder(
   override val databaseName: String,
+  tableName: String,
 ) : SqlQueryBuilder(
   databaseName,
-  "order_details",
+  tableName,
   arrayOf(
     "legacy_subject_id",
     "legacy_order_id",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/SqlQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/SqlQueryBuilder.kt
@@ -7,8 +7,8 @@ import org.apache.commons.lang3.StringUtils.isAlphanumericSpace
 
 open class SqlQueryBuilder(
   open val databaseName: String,
-  val table: String,
-  val fields: Array<String>,
+  open val tableName: String,
+  private val fields: Array<String>,
 ) {
   protected val whereClauses: MutableMap<String, QueryBlock> = mutableMapOf<String, QueryBlock>()
   protected val values: MutableList<String> = mutableListOf<String>()
@@ -47,9 +47,9 @@ open class SqlQueryBuilder(
   }
 
   protected fun getSQL(): String {
-    var query = Query()
+    val query = Query()
       .fields(*fields)
-      .from("$databaseName.$table")
+      .from("$databaseName.$tableName")
 
     whereClauses.forEach {
       query.where(it.value)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchCriteria.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model
 
 data class OrderSearchCriteria(
-  val searchType: String? = null,
+  val searchType: String,
   val legacySubjectId: String? = null,
   val firstName: String? = null,
   val lastName: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
@@ -7,7 +7,8 @@ import java.time.LocalDateTime
 data class OrderSearchResult(
   val dataType: String,
   val legacySubjectId: Long,
-  val name: String?,
+  val firstName: String?,
+  val lastName: String?,
   val alias: String?,
   val addressLine1: String?,
   val addressLine2: String?,
@@ -20,7 +21,8 @@ data class OrderSearchResult(
   constructor(dto: AthenaOrderSearchResultDTO) : this(
     dataType = "am",
     legacySubjectId = dto.legacySubjectId,
-    name = dto.fullName,
+    firstName = dto.firstName,
+    lastName = dto.lastName,
     alias = dto.alias,
     addressLine1 = dto.primaryAddressLine1,
     addressLine2 = dto.primaryAddressLine2,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaOrderSearchResultDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaOrderSearchResultDTO.kt
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class AthenaOrderSearchResultDTO(
   val legacySubjectId: Long,
   val legacyOrderId: String? = "",
-  val fullName: String? = "",
+  val firstName: String? = "",
+  val lastName: String? = "",
   val alias: String? = "",
   @JsonProperty("primary_address_line_1")
   val primaryAddressLine1: String? = "",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SearchRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SearchRepository.kt
@@ -20,7 +20,8 @@ class SearchRepository(
   var athenaDatabase: String = "unknown_database",
 ) {
   fun searchOrders(criteria: OrderSearchCriteria, role: AthenaRole): String {
-    val orderSearchQuery = OrderSearchQueryBuilder(athenaDatabase)
+    val tableName = AthenaHelper.tableNameFromSearchType(criteria.searchType)
+    val orderSearchQuery = OrderSearchQueryBuilder(athenaDatabase, tableName)
       .withLegacySubjectId(criteria.legacySubjectId)
       .withFirstName(criteria.firstName)
       .withLastName(criteria.lastName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
@@ -252,7 +252,10 @@ class AthenaHelperTest {
             "VarCharValue": "legacy_subject_id"
           },
           {
-            "VarCharValue": "full_name"
+            "VarCharValue": "first_name"
+          },
+                    {
+            "VarCharValue": "last_name"
           },
           {
             "VarCharValue": "primary_address_line_1"
@@ -280,7 +283,10 @@ class AthenaHelperTest {
             "VarCharValue": "1253587"
           },
           {
-            "VarCharValue": "ELLEN RIPLY"
+            "VarCharValue": "ELLEN"
+          },
+          {
+            "VarCharValue": "RIPLY"
           },
           {
             "VarCharValue": "310 Lightbowne Road, Moston"
@@ -321,8 +327,20 @@ class AthenaHelperTest {
           "CatalogName": "hive",
           "SchemaName": "",
           "TableName": "",
-          "Name": "full_name",
-          "Label": "full_name",
+          "Name": "first_name",
+          "Label": "first_name",
+          "Type": "varchar",
+          "Precision": "2147483647",
+          "Scale": "0",
+          "Nullable": "UNKNOWN",
+          "CaseSensitive": "true"
+        },
+        {
+          "CatalogName": "hive",
+          "SchemaName": "",
+          "TableName": "",
+          "Name": "last_name",
+          "Label": "last_name",
           "Type": "varchar",
           "Precision": "2147483647",
           "Scale": "0",
@@ -410,7 +428,8 @@ class AthenaHelperTest {
       val expected: List<AthenaOrderSearchResultDTO> = listOf(
         AthenaOrderSearchResultDTO(
           legacySubjectId = 1253587,
-          fullName = "ELLEN RIPLY",
+          firstName = "ELLEN",
+          lastName = "RIPLY",
           primaryAddressLine1 = "310 Lightbowne Road, Moston",
           primaryAddressLine2 = "Moston",
           primaryAddressLine3 = "Manchester",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.helpers
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import software.amazon.awssdk.services.athena.model.ResultSet
@@ -548,6 +549,40 @@ class AthenaHelperTest {
 
       Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java)
         .isThrownBy { AthenaHelper.mapTo<FakeObject>(resultSet) }
+    }
+  }
+
+  @Nested
+  inner class TableNameFromSearchType {
+    @Test
+    fun `assigns correct table for integrity data`() {
+      val searchType = "integrity"
+      val expectedTable = "order_details"
+
+      val actualTable = AthenaHelper.tableNameFromSearchType(searchType)
+
+      Assertions.assertThat(actualTable).isEqualTo(expectedTable)
+    }
+
+    @Test
+    fun `assigns correct table for alcohol monitoring data`() {
+      val searchType = "alcohol-monitoring"
+      val expectedTable = "am_order_details"
+
+      val actualTable = AthenaHelper.tableNameFromSearchType(searchType)
+
+      Assertions.assertThat(actualTable).isEqualTo(expectedTable)
+    }
+
+    @Test
+    fun `fails with 401 when searchType is invalid`() {
+      val searchType = "invalid-type"
+
+      assertThatThrownBy {
+        AthenaHelper.tableNameFromSearchType(searchType)
+      }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("Unknown search type: invalid-type")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
@@ -21,7 +21,7 @@ class OrderSearchQueryBuilderTest {
           order_start_date,
           order_end_date
         FROM 
-          test_database.order_details
+          test_database.test_table
         WHERE 
   """.trimIndent()
 
@@ -37,7 +37,7 @@ class OrderSearchQueryBuilderTest {
 
     val expectedParameters = arrayOf("UPPER('%111222333%')")
 
-    val result = OrderSearchQueryBuilder("test_database")
+    val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withLegacySubjectId(legacySubjectId)
       .build()
 
@@ -55,7 +55,7 @@ class OrderSearchQueryBuilderTest {
       """.trimIndent(),
     )
 
-    val result = OrderSearchQueryBuilder("test_database")
+    val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withFirstName(firstName)
       .build()
 
@@ -68,7 +68,7 @@ class OrderSearchQueryBuilderTest {
     val dangerousInput = "Steve OR 1=1"
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-      OrderSearchQueryBuilder("test_database")
+      OrderSearchQueryBuilder("test_database", "test_table")
         .withFirstName(dangerousInput)
         .build()
     }.withMessage("first_name must only contain alphanumeric characters and spaces")
@@ -84,7 +84,7 @@ class OrderSearchQueryBuilderTest {
       """.trimIndent(),
     )
 
-    val result = OrderSearchQueryBuilder("test_database")
+    val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withLastName(lastName)
       .build()
 
@@ -97,7 +97,7 @@ class OrderSearchQueryBuilderTest {
     val dangerousInput = "Jobs OR 1=1"
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-      OrderSearchQueryBuilder("test_database")
+      OrderSearchQueryBuilder("test_database", "test_table")
         .withLastName(dangerousInput)
         .build()
     }.withMessage("last_name must only contain alphanumeric characters and spaces")
@@ -113,7 +113,7 @@ class OrderSearchQueryBuilderTest {
       """.trimIndent(),
     )
 
-    val result = OrderSearchQueryBuilder("test_database")
+    val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withAlias(alias)
       .build()
 
@@ -126,7 +126,7 @@ class OrderSearchQueryBuilderTest {
     val dangerousInput = "Jobs OR 1=1"
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-      OrderSearchQueryBuilder("test_database")
+      OrderSearchQueryBuilder("test_database", "test_table")
         .withAlias(dangerousInput)
         .build()
     }.withMessage("alias must only contain alphanumeric characters and spaces")
@@ -145,7 +145,7 @@ class OrderSearchQueryBuilderTest {
     )
     val expectedParameters = arrayOf("UPPER('%4%')", "UPPER('%The Big Apple%')")
 
-    val result = OrderSearchQueryBuilder("test_database")
+    val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withLegacySubjectId(legacySubjectId)
       .withAlias(alias)
       .build()
@@ -157,7 +157,7 @@ class OrderSearchQueryBuilderTest {
   @Test
   fun `Throws error if search criteria are null`() {
     Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-      OrderSearchQueryBuilder("fake_database").build()
+      OrderSearchQueryBuilder("fake_database", "test_table").build()
     }.withMessage("At least one search criteria must be populated")
   }
 
@@ -166,7 +166,7 @@ class OrderSearchQueryBuilderTest {
     val illegalLegacySubjectId = "fake-not a number"
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-      OrderSearchQueryBuilder("test_database").withLegacySubjectId(illegalLegacySubjectId)
+      OrderSearchQueryBuilder("test_database", "test_table").withLegacySubjectId(illegalLegacySubjectId)
     }.withMessage("legacy_subject_id must only contain alphanumeric characters and spaces")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
@@ -10,7 +10,8 @@ class OrderSearchQueryBuilderTest {
         SELECT 
           legacy_subject_id,
           legacy_order_id,
-          full_name,
+          first_name,
+          last_name,
           alias,
           date_of_birth,
           primary_address_line_1,
@@ -34,12 +35,14 @@ class OrderSearchQueryBuilderTest {
       """.trimIndent(),
     )
 
+    val expectedParameters = arrayOf("UPPER('%111222333%')")
+
     val result = OrderSearchQueryBuilder("test_database")
       .withLegacySubjectId(legacySubjectId)
       .build()
 
     Assertions.assertThat(replaceWhitespace(result.queryString)).isEqualTo(expectedSQL)
-    Assertions.assertThat(result.parameters).isEqualTo(arrayOf(legacySubjectId))
+    Assertions.assertThat(result.parameters).isEqualTo(expectedParameters)
   }
 
   @Test
@@ -140,6 +143,7 @@ class OrderSearchQueryBuilderTest {
             AND alias LIKE ?
       """.trimIndent(),
     )
+    val expectedParameters = arrayOf("UPPER('%4%')", "UPPER('%The Big Apple%')")
 
     val result = OrderSearchQueryBuilder("test_database")
       .withLegacySubjectId(legacySubjectId)
@@ -147,7 +151,7 @@ class OrderSearchQueryBuilderTest {
       .build()
 
     Assertions.assertThat(replaceWhitespace(result.queryString)).isEqualTo(expectedSQL)
-    Assertions.assertThat(result.parameters).isEqualTo(arrayOf(legacySubjectId, "UPPER('%$alias%')"))
+    Assertions.assertThat(result.parameters).isEqualTo(expectedParameters)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/integration/resources/SearchControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/integration/resources/SearchControllerIntegrationTest.kt
@@ -115,7 +115,8 @@ class SearchControllerIntegrationTest : ControllerIntegrationBase() {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .jsonPath("$.length()").isEqualTo(6)
-        .jsonPath("$[0].name").isEqualTo("Amy Smith")
+        .jsonPath("$[0].firstName").isEqualTo("Amy")
+        .jsonPath("$[0].lastName").isEqualTo("Smith")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
@@ -80,7 +80,8 @@ class SearchControllerTest {
         OrderSearchResult(
           dataType = "am",
           legacySubjectId = 12345,
-          name = "Amy Smith",
+          firstName = "Amy",
+          lastName = "Smith",
           addressLine1 = "First line of address",
           addressLine2 = "Second line of address",
           addressLine3 = "Third line of address",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
@@ -159,7 +159,8 @@ class OrderServiceTest {
           listOf<AthenaOrderSearchResultDTO>(
             AthenaOrderSearchResultDTO(
               legacySubjectId = 1,
-              fullName = "",
+              firstName = "",
+              lastName = "",
               primaryAddressLine1 = "",
               primaryAddressLine2 = "",
               primaryAddressLine3 = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
@@ -102,6 +102,7 @@ class OrderServiceTest {
   @Nested
   inner class SearchOrders {
     private val orderSearchCriteria = OrderSearchCriteria(
+      searchType = "integrity",
       legacySubjectId = "fake-id",
     )
 

--- a/src/test/resources/athenaResponses/successfulOrderSearchResponse.json
+++ b/src/test/resources/athenaResponses/successfulOrderSearchResponse.json
@@ -4,7 +4,8 @@
       {
         "Data": [
           { "VarCharValue": "legacy_subject_id" },
-          { "VarCharValue": "full_name" },
+          { "VarCharValue": "first_name" },
+          { "VarCharValue": "last_name" },
           { "VarCharValue": "primary_address_line_1" },
           { "VarCharValue": "primary_address_line_2" },
           { "VarCharValue": "primary_address_line_3" },
@@ -16,7 +17,8 @@
       {
         "Data": [
           { "VarCharValue": "1000000" },
-          { "VarCharValue": "Amy Smith" },
+          { "VarCharValue": "Amy" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -28,7 +30,8 @@
       {
         "Data": [
           { "VarCharValue": "2000000" },
-          { "VarCharValue": "Bill Smith" },
+          { "VarCharValue": "Bill" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -40,7 +43,8 @@
       {
         "Data": [
           { "VarCharValue": "3000000" },
-          { "VarCharValue": "Claire Smith" },
+          { "VarCharValue": "Claire" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -52,7 +56,8 @@
       {
         "Data": [
           { "VarCharValue": "8000000" },
-          { "VarCharValue": "Daniel Smith" },
+          { "VarCharValue": "Daniel" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -64,7 +69,8 @@
       {
         "Data": [
           { "VarCharValue": "30000" },
-          { "VarCharValue": "Emma Smith" },
+          { "VarCharValue": "Emma" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -76,7 +82,8 @@
       {
         "Data": [
           { "VarCharValue": "4000000" },
-          { "VarCharValue": "Fred Smith" },
+          { "VarCharValue": "Fred" },
+          { "VarCharValue": "Smith" },
           { "VarCharValue": "address line 1" },
           { "VarCharValue": "address line 2" },
           { "VarCharValue": "" },
@@ -104,8 +111,20 @@
           "CatalogName": "hive",
           "SchemaName": "",
           "TableName": "",
-          "Name": "full_name",
-          "Label": "full_name",
+          "Name": "first_name",
+          "Label": "first_name",
+          "Type": "varchar",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "Nullable": "UNKNOWN",
+          "CaseSensitive": true
+        },
+        {
+          "CatalogName": "hive",
+          "SchemaName": "",
+          "TableName": "",
+          "Name": "last_name",
+          "Label": "last_name",
           "Type": "varchar",
           "Precision": 2147483647,
           "Scale": 0,


### PR DESCRIPTION
Updates the order search path:
- Enable searching for alcohol monitoring orders
- Return device wearer first name & last name as separate properties rather than a concatenated full name
- Make legacy order ID matching case insensitive (relevant because AM order IDs can include letters)

_NB: Currently AM orders cannot be searched because column names in the Athena table am_order_details do not match the equivalent column's names in the integrity order_details table, and our SQL query builder expects the tables to have equivalent column names for certain fields. I've contacted data colleagues to check whether our preference is to align column names in the two Athena tables, or separate the AM & integrity search paths / query generators. Either way, the work in this PR is of value, is non-breaking, and can be built on once we've made a decision._