### PR TITLE
Fixes for order search by legacy subject ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilder.kt
@@ -33,8 +33,8 @@ class OrderSearchQueryBuilder(
       return this
     }
 
-    values.add("UPPER('%$value%')")
-    whereClauses.put("legacy_subject_id", "legacy_subject_id" eq "UPPER('%$value%')")
+    values.add("UPPER('$value')")
+    whereClauses.put("legacy_subject_id", "UPPER(CAST(legacy_subject_id as varchar))" eq "UPPER('$value')")
     return this
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/OrderSearchResult.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class OrderSearchResult(
   val dataType: String,
-  val legacySubjectId: Long,
+  val legacySubjectId: String,
   val firstName: String?,
   val lastName: String?,
   val alias: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaOrderSearchResultDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaOrderSearchResultDTO.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athe
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class AthenaOrderSearchResultDTO(
-  val legacySubjectId: Long,
+  val legacySubjectId: String,
   val legacyOrderId: String? = "",
   val firstName: String? = "",
   val lastName: String? = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/AthenaHelperTest.kt
@@ -428,7 +428,7 @@ class AthenaHelperTest {
 
       val expected: List<AthenaOrderSearchResultDTO> = listOf(
         AthenaOrderSearchResultDTO(
-          legacySubjectId = 1253587,
+          legacySubjectId = "1253587",
           firstName = "ELLEN",
           lastName = "RIPLY",
           primaryAddressLine1 = "310 Lightbowne Road, Moston",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/helpers/querybuilders/OrderSearchQueryBuilderTest.kt
@@ -31,11 +31,11 @@ class OrderSearchQueryBuilderTest {
 
     val expectedSQL = replaceWhitespace(
       baseQuery + """
-            legacy_subject_id = ?
+            UPPER(CAST(legacy_subject_id as varchar)) = ?
       """.trimIndent(),
     )
 
-    val expectedParameters = arrayOf("UPPER('%111222333%')")
+    val expectedParameters = arrayOf("UPPER('111222333')")
 
     val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withLegacySubjectId(legacySubjectId)
@@ -139,11 +139,11 @@ class OrderSearchQueryBuilderTest {
 
     val expectedSQL = replaceWhitespace(
       baseQuery + """
-            legacy_subject_id = ?
+            UPPER(CAST(legacy_subject_id as varchar)) = ?
             AND alias LIKE ?
       """.trimIndent(),
     )
-    val expectedParameters = arrayOf("UPPER('%4%')", "UPPER('%The Big Apple%')")
+    val expectedParameters = arrayOf("UPPER('4')", "UPPER('%The Big Apple%')")
 
     val result = OrderSearchQueryBuilder("test_database", "test_table")
       .withLegacySubjectId(legacySubjectId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/resources/SearchControllerTest.kt
@@ -79,7 +79,7 @@ class SearchControllerTest {
       val expectedResult = listOf(
         OrderSearchResult(
           dataType = "am",
-          legacySubjectId = 12345,
+          legacySubjectId = "12345",
           firstName = "Amy",
           lastName = "Smith",
           addressLine1 = "First line of address",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderServiceTest.kt
@@ -159,7 +159,7 @@ class OrderServiceTest {
         .thenReturn(
           listOf<AthenaOrderSearchResultDTO>(
             AthenaOrderSearchResultDTO(
-              legacySubjectId = 1,
+              legacySubjectId = "1",
               firstName = "",
               lastName = "",
               primaryAddressLine1 = "",


### PR DESCRIPTION
Fixes aspects of order searching using `legacy_subject_id`:
- In Athena, the integrity `order_details` table uses type `Long` for legacy_subject_id. The AM table uses type `String` for this field. Previously this wasn't handled, causing errors. Now the order search route can handle both types. The tables are also being updated to use `String` type in both tables (no additional changes will be needed in this repo when that occurs).
- Process the legacy_subject_id returned by Athena as a `string`, not a `long`.
- Allow case insensitive matching of legacy_subject_id. This is relevant as AM IDs include letters.