### PR TITLE
Process legacySubjectId and legacyOrderId as strings in all paths. 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/CurfewTimetable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/CurfewTimetable.kt
@@ -24,8 +24,8 @@ data class CurfewTimetable(
   val sunday: Int,
 ) {
   constructor(dto: AthenaCurfewTimetableDTO) : this (
-    legacySubjectId = dto.legacySubjectId.toString(),
-    legacyOrderId = dto.legacyOrderId.toString(),
+    legacySubjectId = dto.legacySubjectId,
+    legacyOrderId = dto.legacyOrderId,
     serviceId = dto.serviceId,
     serviceAddress1 = dto.serviceAddress1,
     serviceAddress2 = dto.serviceAddress2,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/EquipmentDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/EquipmentDetails.kt
@@ -18,8 +18,8 @@ data class EquipmentDetails(
   val hmu: EquipmentDetail?,
 ) {
   constructor(dto: AthenaEquipmentDetailsDTO) : this(
-    legacySubjectId = dto.legacySubjectId.toString(),
-    legacyOrderId = dto.legacyOrderId.toString(),
+    legacySubjectId = dto.legacySubjectId,
+    legacyOrderId = dto.legacyOrderId,
     pid = if (!dto.pidId.isNullOrEmpty()) {
       EquipmentDetail(
         id = dto.pidId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/SuspensionOfVisits.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/SuspensionOfVisits.kt
@@ -15,8 +15,8 @@ data class SuspensionOfVisits(
 ) {
 
   constructor(dto: AthenaSuspensionOfVisitsDTO) : this(
-    legacySubjectId = dto.legacySubjectId.toString(),
-    legacyOrderId = dto.legacyOrderId.toString(),
+    legacySubjectId = dto.legacySubjectId,
+    legacyOrderId = dto.legacyOrderId,
     suspensionOfVisits = dto.suspensionOfVisits,
     requestedDate = nullableLocalDateTime(dto.suspensionOfVisitsRequestedDate),
     startDate = nullableLocalDateTime(dto.suspensionOfVisitsStartDate),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/VisitDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/VisitDetails.kt
@@ -24,8 +24,8 @@ data class VisitDetails(
 ) {
 
   constructor(dto: AthenaVisitDetailsDTO) : this(
-    legacySubjectId = dto.legacySubjectId.toString(),
-    legacyOrderId = dto.legacyOrderId.toString(),
+    legacySubjectId = dto.legacySubjectId,
+    legacyOrderId = dto.legacyOrderId,
     address = if (
       !dto.address1.isNullOrEmpty() ||
       !dto.address2.isNullOrEmpty() ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaContactEventDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaContactEventDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaContactEventDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val outcome: String?,
   val contactType: String?,
   val reason: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaCurfewTimetableDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaCurfewTimetableDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaCurfewTimetableDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val serviceId: Int,
   val serviceAddress1: String?,
   val serviceAddress2: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaEquipmentDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaEquipmentDetailsDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaEquipmentDetailsDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val hmuId: String?,
   val hmuEquipmentCategoryDescription: String?,
   val hmuInstallDate: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaIncidentEventDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaIncidentEventDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaIncidentEventDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val violationAlertType: String?,
   val violationAlertDate: String?,
   val violationAlertTime: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaMonitoringEventDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaMonitoringEventDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaMonitoringEventDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val eventType: String?,
   val eventDate: String?,
   val eventTime: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaSuspensionOfVisitsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaSuspensionOfVisitsDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaSuspensionOfVisitsDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val suspensionOfVisits: String?,
   val suspensionOfVisitsRequestedDate: String?,
   val suspensionOfVisitsStartDate: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaViolationEventDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaViolationEventDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaViolationEventDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val enforcementReason: String?,
   val investigationOutcomeReason: String?,
   val breachDetails: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaVisitDetailsDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaVisitDetailsDTO.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatastoreapi.model.athena
 
 data class AthenaVisitDetailsDTO(
-  val legacySubjectId: Int,
-  val legacyOrderId: Int,
+  val legacySubjectId: String,
+  val legacyOrderId: String,
   val address1: String?,
   val address2: String?,
   val address3: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/VisitDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/VisitDetailsTest.kt
@@ -12,8 +12,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped with all attributes`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address_1",
         address2 = "address_2",
         address3 = "address_3",
@@ -52,8 +52,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped with the minimum details`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = null,
         address2 = null,
         address3 = null,
@@ -86,8 +86,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without any address details`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = null,
         address2 = null,
         address3 = null,
@@ -120,8 +120,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without any visit notes`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address_1",
         address2 = "address_2",
         address3 = "address_3",
@@ -160,8 +160,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without any visit outcome`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address_1",
         address2 = "address_2",
         address3 = "address_3",
@@ -200,8 +200,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without any end date`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address_1",
         address2 = "address_2",
         address3 = "address_3",
@@ -240,8 +240,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without a complete address`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = null,
         address2 = null,
         address3 = null,
@@ -280,8 +280,8 @@ class VisitDetailsTest {
     @Test
     fun `VisitDetails can be mapped without a postcode`() {
       val athenaDto = AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address line 1",
         address2 = null,
         address3 = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaViolationEventDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaViolationEventDTOTest.kt
@@ -71,8 +71,8 @@ class AthenaViolationEventDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaViolationEventDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           enforcementReason = "TEST_ENFORCEMENT_REASON",
           investigationOutcomeReason = "TEST_OUTCOME_REASON",
           breachDetails = "some details",
@@ -133,8 +133,8 @@ class AthenaViolationEventDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaViolationEventDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           enforcementReason = null,
           investigationOutcomeReason = null,
           breachDetails = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaVisitDetailsDTOTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/model/athena/AthenaVisitDetailsDTOTest.kt
@@ -52,8 +52,8 @@ class AthenaVisitDetailsDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaVisitDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           address1 = "address_1",
           address2 = "address_2",
           address3 = "address_3",
@@ -96,8 +96,8 @@ class AthenaVisitDetailsDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaVisitDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           address1 = null,
           address2 = null,
           address3 = null,
@@ -140,8 +140,8 @@ class AthenaVisitDetailsDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaVisitDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           address1 = "address_1",
           address2 = "address_2",
           address3 = "address_3",
@@ -184,8 +184,8 @@ class AthenaVisitDetailsDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaVisitDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           address1 = "address_1",
           address2 = "address_2",
           address3 = "address_3",
@@ -228,8 +228,8 @@ class AthenaVisitDetailsDTOTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaVisitDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           address1 = "address_1",
           address2 = "address_2",
           address3 = "address_3",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/models/EquipmentDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/models/EquipmentDetailsTest.kt
@@ -14,8 +14,8 @@ class EquipmentDetailsTest {
     @Test
     fun `AthenaEquipmentDetailsDto can be mapped without any equipment details`() {
       val athenaDto = AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = null,
         hmuEquipmentCategoryDescription = null,
         hmuInstallDate = null,
@@ -45,8 +45,8 @@ class EquipmentDetailsTest {
     @Test
     fun `AthenaEquipmentDetailsDto can be mapped without any home monitoring unit equipment details`() {
       val athenaDto = AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = null,
         hmuEquipmentCategoryDescription = null,
         hmuInstallDate = null,
@@ -81,8 +81,8 @@ class EquipmentDetailsTest {
     @Test
     fun `AthenaEquipmentDetailsDto can be mapped without any personal equipment details`() {
       val athenaDto = AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = "hmu_id",
         hmuEquipmentCategoryDescription = "hmu_equipment_category_description",
         hmuInstallDate = "2020-02-02",
@@ -117,8 +117,8 @@ class EquipmentDetailsTest {
     @Test
     fun `AthenaEquipmentDetailsDto can be mapped with just equipment ids`() {
       val athenaDto = AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = "hmu_id",
         hmuEquipmentCategoryDescription = null,
         hmuInstallDate = null,
@@ -158,8 +158,8 @@ class EquipmentDetailsTest {
     @Test
     fun `AthenaEquipmentDetailsDto can be mapped with no times`() {
       val athenaDto = AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = "hmu_id",
         hmuEquipmentCategoryDescription = null,
         hmuInstallDate = "2021-02-02",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/models/athena/AthenaEquipmentDetailsDtoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/models/athena/AthenaEquipmentDetailsDtoTest.kt
@@ -55,8 +55,8 @@ class AthenaEquipmentDetailsDtoTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaEquipmentDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           hmuId = null,
           hmuEquipmentCategoryDescription = null,
           hmuInstallDate = null,
@@ -101,8 +101,8 @@ class AthenaEquipmentDetailsDtoTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaEquipmentDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           hmuId = null,
           hmuEquipmentCategoryDescription = null,
           hmuInstallDate = null,
@@ -147,8 +147,8 @@ class AthenaEquipmentDetailsDtoTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaEquipmentDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           hmuId = "hmu_id",
           hmuEquipmentCategoryDescription = "hmu_equipment_category_description",
           hmuInstallDate = "hmu_install_date",
@@ -193,8 +193,8 @@ class AthenaEquipmentDetailsDtoTest {
 
       Assertions.assertThat(dto.first()).isEqualTo(
         AthenaEquipmentDetailsDTO(
-          legacySubjectId = 123,
-          legacyOrderId = 321,
+          legacySubjectId = "123",
+          legacyOrderId = "321",
           hmuId = "hmu_id",
           hmuEquipmentCategoryDescription = null,
           hmuInstallDate = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/CurfewTimetableRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/CurfewTimetableRepositoryTest.kt
@@ -34,6 +34,7 @@ class CurfewTimetableRepositoryTest {
     fun servicesResultSet(firstId: String = "987123") = MockAthenaResultSetBuilder(
       columns = arrayOf(
         "legacy_subject_id",
+        "legacy_order_id",
         "service_id",
         "service_address_1",
         "service_address_2",
@@ -56,6 +57,7 @@ class CurfewTimetableRepositoryTest {
       rows = arrayOf(
         arrayOf(
           firstId,
+          firstId,
           "333",
           "service_address_1",
           "service_address_2",
@@ -77,6 +79,7 @@ class CurfewTimetableRepositoryTest {
         ),
         arrayOf(
           "123456789",
+          "987654321",
           "444",
           "service_address_1",
           "service_address_2",
@@ -133,7 +136,7 @@ class CurfewTimetableRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaCurfewTimetableDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
       Assertions.assertThat(result.first().serviceId).isEqualTo(333)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/EquipmentDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/EquipmentDetailsRepositoryTest.kt
@@ -118,7 +118,7 @@ class EquipmentDetailsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaEquipmentDetailsDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderEventsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/OrderEventsRepositoryTest.kt
@@ -106,8 +106,8 @@ class OrderEventsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaMonitoringEventDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
-      Assertions.assertThat(result.first().legacyOrderId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
+      Assertions.assertThat(result.first().legacyOrderId).isEqualTo("987")
       Assertions.assertThat(result.first().eventType).isEqualTo("TEST_EVENT")
     }
   }
@@ -174,8 +174,8 @@ class OrderEventsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaIncidentEventDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
-      Assertions.assertThat(result.first().legacyOrderId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
+      Assertions.assertThat(result.first().legacyOrderId).isEqualTo("987")
       Assertions.assertThat(result.first().violationAlertType).isEqualTo("TEST_ALERT")
     }
   }
@@ -293,8 +293,8 @@ class OrderEventsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaViolationEventDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
-      Assertions.assertThat(result.first().legacyOrderId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
+      Assertions.assertThat(result.first().legacyOrderId).isEqualTo("987")
       Assertions.assertThat(result.first().investigationOutcomeReason).isEqualTo("TEST_OUTCOME_REASON")
     }
   }
@@ -379,8 +379,8 @@ class OrderEventsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaContactEventDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
-      Assertions.assertThat(result.first().legacyOrderId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
+      Assertions.assertThat(result.first().legacyOrderId).isEqualTo("987")
       Assertions.assertThat(result.first().contactType).isEqualTo("TEST_CONTACT")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SuspensionOfVisitsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/SuspensionOfVisitsRepositoryTest.kt
@@ -36,6 +36,7 @@ class SuspensionOfVisitsRepositoryTest {
     fun suspensionOfVisitsResultSet(firstId: String = "987123") = MockAthenaResultSetBuilder(
       columns = arrayOf(
         "legacy_subject_id",
+        "legacy_order_id",
         "suspension_of_visits",
         "suspension_of_visits_requested_date",
         "suspension_of_visits_start_date",
@@ -45,6 +46,7 @@ class SuspensionOfVisitsRepositoryTest {
       rows = arrayOf(
         arrayOf(
           firstId,
+          firstId,
           "Yes",
           "2024-02-02T02:02:02",
           "2024-02-02",
@@ -53,6 +55,7 @@ class SuspensionOfVisitsRepositoryTest {
         ),
         arrayOf(
           "123456789",
+          "987654321",
           "No",
           "2024-02-02T02:02:02",
           "2024-02-02",
@@ -65,6 +68,7 @@ class SuspensionOfVisitsRepositoryTest {
     fun suspensionOfVisitsNoStartResultSet(firstId: String = "987123") = MockAthenaResultSetBuilder(
       columns = arrayOf(
         "legacy_subject_id",
+        "legacy_order_id",
         "suspension_of_visits",
         "suspension_of_visits_requested_date",
         "suspension_of_visits_start_date",
@@ -73,6 +77,7 @@ class SuspensionOfVisitsRepositoryTest {
       ),
       rows = arrayOf(
         arrayOf(
+          firstId,
           firstId,
           "Yes",
           "2024-02-02T02:02:02",
@@ -117,7 +122,7 @@ class SuspensionOfVisitsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaSuspensionOfVisitsDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
     }
 
     @Test
@@ -132,7 +137,7 @@ class SuspensionOfVisitsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(1)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaSuspensionOfVisitsDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/VisitDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/repository/VisitDetailsRepositoryTest.kt
@@ -115,7 +115,7 @@ class VisitDetailsRepositoryTest {
       Assertions.assertThat(result.size).isEqualTo(2)
 
       Assertions.assertThat(result.first()).isInstanceOf(AthenaVisitDetailsDTO::class.java)
-      Assertions.assertThat(result.first().legacySubjectId).isEqualTo(987)
+      Assertions.assertThat(result.first().legacySubjectId).isEqualTo("987")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/CurfewTimetableServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/CurfewTimetableServiceTest.kt
@@ -33,8 +33,8 @@ class CurfewTimetableServiceTest {
 
     val exampleCurfewTimetable = listOf<AthenaCurfewTimetableDTO>(
       AthenaCurfewTimetableDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 123,
+        legacySubjectId = "123",
+        legacyOrderId = "123",
         serviceId = 333,
         serviceAddress1 = "",
         serviceAddress2 = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/EquipmentDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/EquipmentDetailsServiceTest.kt
@@ -34,8 +34,8 @@ class EquipmentDetailsServiceTest {
 
     val exampleEquipmentDetailsList = listOf<AthenaEquipmentDetailsDTO>(
       AthenaEquipmentDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         hmuId = "123X",
         hmuEquipmentCategoryDescription = "TEST_HMU_CATEGORY",
         hmuInstallDate = "2020-02-02",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/OrderEventsServiceTest.kt
@@ -40,8 +40,8 @@ class OrderEventsServiceTest {
 
     val exampleMonitoringEventList = listOf<AthenaMonitoringEventDTO>(
       AthenaMonitoringEventDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 123,
+        legacySubjectId = "123",
+        legacyOrderId = "123",
         eventType = "TEST_EVENT",
         eventDate = "2022-10-10",
         eventTime = "13:00:05",
@@ -93,8 +93,8 @@ class OrderEventsServiceTest {
 
     val exampleIncidentEventList = listOf<AthenaIncidentEventDTO>(
       AthenaIncidentEventDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 123,
+        legacySubjectId = "123",
+        legacyOrderId = "123",
         violationAlertType = "TEST_VIOLATION",
         violationAlertDate = "2019-06-24",
         violationAlertTime = "05:38:23",
@@ -142,8 +142,8 @@ class OrderEventsServiceTest {
 
     val exampleViolationEventList = listOf<AthenaViolationEventDTO>(
       AthenaViolationEventDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 123,
+        legacySubjectId = "123",
+        legacyOrderId = "123",
         enforcementReason = "TEST_REASON",
         investigationOutcomeReason = "TEST_OUTCOME",
         breachDetails = "TEST_BREACH",
@@ -208,8 +208,8 @@ class OrderEventsServiceTest {
 
     val exampleContactEventList = listOf<AthenaContactEventDTO>(
       AthenaContactEventDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 123,
+        legacySubjectId = "123",
+        legacyOrderId = "123",
         outcome = "Mr silly laughed out loud",
         contactType = "TEST_CONTACT",
         reason = "A silly reason",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/SuspensionOfVisitsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/SuspensionOfVisitsServiceTest.kt
@@ -33,8 +33,8 @@ class SuspensionOfVisitsServiceTest {
 
     val exampleSuspensionOfVisits = listOf<AthenaSuspensionOfVisitsDTO>(
       AthenaSuspensionOfVisitsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 456,
+        legacySubjectId = "123",
+        legacyOrderId = "456",
         suspensionOfVisits = "Yes",
         suspensionOfVisitsRequestedDate = "2023-03-03",
         suspensionOfVisitsStartDate = "2023-04-04",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/VisitDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatastoreapi/services/VisitDetailsServiceTest.kt
@@ -34,8 +34,8 @@ class VisitDetailsServiceTest {
 
     val exampleVisitDetails = listOf<AthenaVisitDetailsDTO>(
       AthenaVisitDetailsDTO(
-        legacySubjectId = 123,
-        legacyOrderId = 321,
+        legacySubjectId = "123",
+        legacyOrderId = "321",
         address1 = "address_line_1",
         address2 = "address_line_2",
         address3 = "address_line_3",

--- a/src/test/resources/athenaResponses/successfulContactEventsResponse.json
+++ b/src/test/resources/athenaResponses/successfulContactEventsResponse.json
@@ -85,28 +85,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulCurfewTimetableResponse.json
+++ b/src/test/resources/athenaResponses/successfulCurfewTimetableResponse.json
@@ -7,6 +7,9 @@
             "VarCharValue": "legacy_subject_id"
           },
           {
+            "VarCharValue": "legacy_order_id"
+          },
+          {
             "VarCharValue": "service_id"
           },
           {
@@ -71,6 +74,9 @@
             "VarCharValue": "1665859"
           },
           {
+            "VarCharValue": "2390735"
+          },
+          {
             "VarCharValue": "Unit 1, Lamby Workshops, Lamby Way, Rumney"
           },
           {
@@ -132,6 +138,9 @@
             "VarCharValue": "1665858"
           },
           {
+            "VarCharValue": "2390734"
+          },
+          {
             "VarCharValue": "Unit 1, Lamby Workshops, Lamby Way, Rumney"
           },
           {
@@ -188,16 +197,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": true,
+          "CatalogName": "hive",
+          "Label": "legacy_order_id",
+          "Name": "legacy_order_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
         },
         {
           "CaseSensitive": false,

--- a/src/test/resources/athenaResponses/successfulEquipmentDetailsResponse.json
+++ b/src/test/resources/athenaResponses/successfulEquipmentDetailsResponse.json
@@ -143,28 +143,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": false,

--- a/src/test/resources/athenaResponses/successfulIncidentEventsResponse.json
+++ b/src/test/resources/athenaResponses/successfulIncidentEventsResponse.json
@@ -81,28 +81,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulMonitoringEventsResponse.json
+++ b/src/test/resources/athenaResponses/successfulMonitoringEventsResponse.json
@@ -98,28 +98,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulOrderDetailsResponse.json
+++ b/src/test/resources/athenaResponses/successfulOrderDetailsResponse.json
@@ -5,28 +5,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulSuspensionOfVisitsResponse.json
+++ b/src/test/resources/athenaResponses/successfulSuspensionOfVisitsResponse.json
@@ -5,28 +5,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulViolationEventsResponse.json
+++ b/src/test/resources/athenaResponses/successfulViolationEventsResponse.json
@@ -179,28 +179,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,

--- a/src/test/resources/athenaResponses/successfulVisitDetailsResponse.json
+++ b/src/test/resources/athenaResponses/successfulVisitDetailsResponse.json
@@ -134,28 +134,28 @@
     "ResultSetMetadata": {
       "ColumnInfo": [
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_subject_id",
           "Name": "legacy_subject_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
-          "CaseSensitive": false,
+          "CaseSensitive": true,
           "CatalogName": "hive",
           "Label": "legacy_order_id",
           "Name": "legacy_order_id",
           "Nullable": "UNKNOWN",
-          "Precision": 19,
+          "Precision": 2147483647,
           "Scale": 0,
           "SchemaName": "",
           "TableName": "",
-          "Type": "bigint"
+          "Type": "varchar"
         },
         {
           "CaseSensitive": true,


### PR DESCRIPTION
- Process legacySubjectId and legacyOrderId as strings in all paths
- Add legacyOrderId to curfewTimetable model

