### PR TITLE
Configure dev deployment to use Athena role ARNs from kubernetes  secrests.

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
@@ -37,6 +37,9 @@ generic-service:
     sqs-hmpps-audit-secret:
       HMPPS_SQS_QUEUES_AUDIT_QUEUEARN: "sqs_queue_arn"
       HMPPS_SQS_QUEUES_AUDIT_QUEUENAME: "sqs_queue_name"
+    hmpps-electronic-monitoring-datastore-dev-athena-roles:
+      ATHENA_GENERAL_IAM_ROLE: "general_role_arn"
+      ATHENA_SPECIALS_IAM_ROLE: "specials_role_arn"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,10 +16,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     ATHENA_DATABASE_NAME: "historic_api_mart"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
-
-    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
-    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
-    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
   #                                  <== COMMENTED OUT to investigate failing build 20/12/2024


### PR DESCRIPTION
- Configure dev deployment to use Athena role ARNs from kubernetes secrets.
  - These secrets are in place in the dev namespace following[ this PR to cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/pull/32383).
  - Previously the general (non-Specials) ARN was assigned to both roles. Now each role is passed the correct ARN; general for the general user, specials for the specials user.
- Remove hardcoded ARNs from `values-dev.yaml`.

This only changes the dev deployment of the service. Once we've established a process for providing the ARNs in dev, and we've checked that this works, then we can extend this process to preprod & prod. At that point, no ARNs will be stored within this repo.