### PR TITLE
Preprod environment gets athena ccess role ARNs from kubernetes secrets

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-datastore-api/values.yaml
@@ -37,7 +37,7 @@ generic-service:
     sqs-hmpps-audit-secret:
       HMPPS_SQS_QUEUES_AUDIT_QUEUEARN: "sqs_queue_arn"
       HMPPS_SQS_QUEUES_AUDIT_QUEUENAME: "sqs_queue_name"
-    hmpps-electronic-monitoring-datastore-dev-athena-roles:
+    athena-roles:
       ATHENA_GENERAL_IAM_ROLE: "general_role_arn"
       ATHENA_SPECIALS_IAM_ROLE: "specials_role_arn"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,10 +16,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     ATHENA_DATABASE_NAME: "historic_api_mart"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
-
-    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
-    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
-    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
   #                                  <== COMMENTED OUT to investigate failing build 20/12/2024


### PR DESCRIPTION
- Remove hardcoded athena access role ARNs from `values-preprod.yaml`. Preprod deployment will now use values from kubernetes secrets.
- Shorten name of `athena-roles` secret in `values.yaml`. The kubernetes secret name has been changed to match in `cloud-platform-environments`.