### PR TITLE
Prod environment gets athena access role ARNs from kubernetes secrets

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,10 +15,6 @@ generic-service:
     ATHENA_DATABASE_NAME: "historic_api_mart"
 #    ATHENA_OUTPUT_BUCKET: "s3://emds-prod-athena-query-results-20240918073115959600000002"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
-
-    # ROLES NOTE: Currently the specials role is set to the same non-specials IAM role as the general role. This will change once we pull specials through.
-    ATHENA_SPECIALS_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
-    ATHENA_GENERAL_IAM_ROLE: "arn:aws:iam::396913731313:role/cmt_read_emds_data_test"
     MFA_REQUIRED: "false"
 
 #  namespace_secrets:


### PR DESCRIPTION
Remove hardcoded athena access role ARNs from values-prod.yaml. Prod deployment will now use values from kubernetes secrets.